### PR TITLE
feat(content) add and use LineLink inline component

### DIFF
--- a/components/content/LineLink.vue
+++ b/components/content/LineLink.vue
@@ -1,0 +1,21 @@
+<template>
+  <a :href="`/voie-lyonnaise-${voie.line}`" :style="`color: ${voie.color}; text-decoration-color: ${voie.color};`">
+    Voie Lyonnaise
+    <span
+      class="h-6 w-6 rounded-full inline-flex items-center justify-center text-white"
+      :style="`background-color: ${voie.color};`"
+    >
+      {{ voie.line }}
+    </span>
+  </a>
+</template>
+
+<script setup>
+const props = defineProps({
+  line: { type: String, required: true }
+})
+
+const { data: voie } = await useAsyncData(props.line, () => {
+  return queryContent('voies-lyonnaises').where({ _type: 'markdown', line: Number(props.line) }).findOne()
+})
+</script>

--- a/components/content/LineLink.vue
+++ b/components/content/LineLink.vue
@@ -1,21 +1,21 @@
 <template>
-  <a :href="`/voie-lyonnaise-${voie.line}`" :style="`color: ${voie.color}; text-decoration-color: ${voie.color};`">
+  <NuxtLink :to="`/voie-lyonnaise-${line}`" :style="`color: ${color}; text-decoration-color: ${color};`">
     Voie Lyonnaise
     <span
       class="h-6 w-6 rounded-full inline-flex items-center justify-center text-white"
-      :style="`background-color: ${voie.color};`"
+      :style="`background-color: ${color};`"
     >
-      {{ voie.line }}
+      {{ line }}
     </span>
-  </a>
+  </NuxtLink>
 </template>
 
 <script setup>
+const { getLineColor } = useColors();
+
 const props = defineProps({
   line: { type: String, required: true }
-})
+});
 
-const { data: voie } = await useAsyncData(props.line, () => {
-  return queryContent('voies-lyonnaises').where({ _type: 'markdown', line: Number(props.line) }).findOne()
-})
+const color = getLineColor(Number(props.line));
 </script>

--- a/content/voies-lyonnaises/ligne-1.md
+++ b/content/voies-lyonnaises/ligne-1.md
@@ -59,9 +59,7 @@ credit: Passagers des Villes / Métropole de Lyon.
 ::
 
 ### Stalingrad Nord
-Cette section est en tronçon commun avec la Voie Lyonnaise 2.  
-Se référer à [la page de la ligne](https://cyclopolis.fr/voie-lyonnaise-2){:target="_blank"} pour davantage d'informations.
-
+Cette section est en tronçon commun avec la :line-link{line=2}.
 
 ### Cité Internationale à Halle Tony Garnier<br>*via Quais du Rhône rive gauche*
 #### Allée Achille Lignon

--- a/content/voies-lyonnaises/ligne-10.md
+++ b/content/voies-lyonnaises/ligne-10.md
@@ -13,9 +13,9 @@ cover: https://cyclopolis.lavilleavelo.org/vl10/voie-lyonnaise-10.png
 
 ### Tassin - Valvert à Tête d'Or - Verguin
 Sur toute la moitié Ouest de son itinéraire, la Voie Lyonnaise 10 est en tronçon commun avec d'autres Voies Lyonnaises :
- - [Voie Lyonnaise 8](https://cyclopolis.fr/voie-lyonnaise-8) du boulevard du Valvert à l'avenue Victor Hugo
- - [Voie Lyonnaise 5](https://cyclopolis.fr/voie-lyonnaise-5) pour la traversée de Vaise
- - [Voie Lyonnaise 4](https://cyclopolis.fr/voie-lyonnaise-4) du pont Clémenceau à l'avenue Verguin
+ - :line-link{line=8} du boulevard du Valvert à l'avenue Victor Hugo
+ - :line-link{line=5} pour la traversée de Vaise
+ - :line-link{line=4} du pont Clémenceau à l'avenue Verguin
 
 Se référer à la page de chaque ligne pour davantage d'informations.
 
@@ -24,8 +24,7 @@ Cette portion sera aménagée en provisoire dans l'attente des travaux du projet
 Les deux voies de circulation générale actuelles seront réduites à une voie unique, ce qui permettra d'élargir les couloirs bus bilatéraux et d'améliorer la cohabitation entre vélos, bus, taxis et services de secours. Cependant, ce tronçon ne sera tout de même pas conforme aux exigences de sécurité d'une Voie Lyonnaise.
 
 ### Boulevard des Belges - de Waldeck Rousseau à Lafayette
-Cette section est en tronçon commun avec la Voie Lyonnaise 2.  
-Se référer à [la page de la ligne](https://cyclopolis.fr/voie-lyonnaise-2) pour davantage d'informations.
+Cette section est en tronçon commun avec la :line-link{line=2}.
 
 ### Pôle d'échange Part-Dieu
 Sur ce tronçon entre la rue Lafayette et l'avenue Georges Pompidou, la Voie Lyonnaise 10 empruntera le boulevard Vivier-Merle en surface au sein du pôle d'échange de la gare Part-Dieu.  

--- a/content/voies-lyonnaises/ligne-11.md
+++ b/content/voies-lyonnaises/ligne-11.md
@@ -17,12 +17,10 @@ La Voie Lyonnaise 11 débutera place Bénédict Teissier au coeur du quartier du
 *Aucune information publique n'existe à ce jour sur ce tronçon.*
 
 ### Traversée de Saint-Just<br/>Traversée de Saint-Jean
-Cette section est en tronçon commun avec la Voie Lyonnaise 12.  
-Se référer à [la page de la ligne](https://cyclopolis.fr/voie-lyonnaise-12) pour davantage d'informations.
+Cette section est en tronçon commun avec la :line-link{line=12}.
 
 ### Traversée de la Presqu'Île de Lyon
-Cette section est en tronçon commun avec la Voie Lyonnaise 8.  
-Se référer à [la page de la ligne](https://cyclopolis.fr/voie-lyonnaise-8) pour davantage d'informations.
+Cette section est en tronçon commun avec la :line-link{line=8}.
 
 ### Pont Wilson
 Depuis la place Bellecour, la Voie Lyonnaise 11 remontera la rive droite du Rhône en tronçon commun avec la Voie Lyonnaise 6, puis traversera le Rhône par le pont Wilson, qui a été aménagé avec une piste cyclable bidirectionnelle de 3.50m côté Nord début 2022 en lieu et place d'une voie de circulation.
@@ -55,8 +53,7 @@ credit: Métropole de Lyon
 [Voir le dossier de concertation (p.13 à p.19)](https://www.grandlyon.com/fileadmin/user_upload/media/pdf/grands-projets/concertation-reglementaire/20230608_voieslyonnaises_ligne11_dossier.pdf)
 
 ### Rue Garibaldi - *Bonnel à Paul Bert*
-Cette section est en tronçon commun avec la Voie Lyonnaise 7.  
-Se référer à [la page de la ligne](https://cyclopolis.fr/voie-lyonnaise-7) pour davantage d'informations.
+Cette section est en tronçon commun avec la :line-link{line=7}.
 
 ### Rue Paul Bert - *Garibaldi à Vivier-Merle*
 Sur cette rue à fort trafic, une piste bidirectionnelle temporaire a été marqué sur le trottoir Nord à l'été 2018, puis supprimée à l'été 2021 au profit de deux bandes cyclables bilatérales sur la chaussée à la place d'une voie de circulation.
@@ -75,8 +72,7 @@ credit: Métropole de Lyon
 [Voir le dossier de concertation (p.20 à p.24)](https://www.grandlyon.com/fileadmin/user_upload/media/pdf/grands-projets/concertation-reglementaire/20230608_voieslyonnaises_ligne11_dossier.pdf)
 
 ### Boulevard Vivier-Merle - *Paul Bert à Félix Faure*
-Cette section est en tronçon commun avec la Voie Lyonnaise 2.  
-Se référer à [la page de la ligne](https://cyclopolis.fr/voie-lyonnaise-2) pour davantage d'informations.
+Cette section est en tronçon commun avec la :line-link{line=2}.
 
 ### Avenue Félix Faure - *Vivier Merle à Esplanade Mandela*
 Sur cette section, la Voie Lyonnaise 11 partagera son itinéraire avec le futur Bus à Haut Niveau de Service (BHNS) entre Part-Dieu et Sept Chemins. Sa réalisation sera traitée en même temps que les travaux de cette ligne, sous maitrise d'ouvrage SYTRAL Mobilités.
@@ -106,8 +102,7 @@ credit: Métropole de Lyon
 [Voir le dossier de concertation (p.25 à p.31)](https://www.grandlyon.com/fileadmin/user_upload/media/pdf/grands-projets/concertation-reglementaire/20230608_voieslyonnaises_ligne11_dossier.pdf)
 
 ### Dauphiné - Lacassagne à Reconnaissance - Balzac
-Cette section est en tronçon commun avec la Voie Lyonnaise 10.  
-Se référer à [la page de la ligne](https://cyclopolis.fr/voie-lyonnaise-10) pour davantage d'informations.
+Cette section est en tronçon commun avec la :line-link{line=10}.
 
 ### Reconnaissance - Balzac à Bron - Sept Chemins
 Sur cette section, la Voie Lyonnaise 11 partagera son itinéraire avec le futur Bus à Haut Niveau de Service (BHNS) entre Part-Dieu et Sept Chemins sur la route de Genas. Sa réalisation sera traitée en même temps que les travaux de cette ligne, sous maitrise d'ouvrage SYTRAL Mobilités.

--- a/content/voies-lyonnaises/ligne-2.md
+++ b/content/voies-lyonnaises/ligne-2.md
@@ -12,8 +12,7 @@ cover: https://cyclopolis.lavilleavelo.org/vl2/bd-vivier-merle.jpg
 ## Les tronçons (du Nord au Sud)
 
 ### Fontaines sur Saône à l'Île Barbe
-Cette section est en tronçon commun avec la Voie Lyonnaise 3.  
-Se référer à [la page de la ligne](https://cyclopolis.fr/voie-lyonnaise-3) pour davantage d'informations.
+Cette section est en tronçon commun avec la :line-link{line=3}.
 
 ### Traversée du Plateau Nord<br/>*Commune de Caluire-et-Cuire*
 #### Île Barbe à Caluire Centre

--- a/content/voies-lyonnaises/ligne-5.md
+++ b/content/voies-lyonnaises/ligne-5.md
@@ -58,8 +58,7 @@ L'enquête publique aura lieu du 4 septembre au 3 octobre 2023.
 Les premiers travaux sur les réseaux débuteront au premier semestre 2024, et s'enchaineront avec les travaux d'aménagements jusqu'à début 2026.
 
 #### Vaulx-en-Velin - Gabriel Péri à La Doua - Croix-Luizet
-Cette section est en tronçon commun avec la Voie Lyonnaise 1.  
-Se référer à [la page de la ligne](https://cyclopolis.fr/voie-lyonnaise-1) pour davantage d'informations.
+Cette section est en tronçon commun avec la :line-link{line=1}.
 
 #### Traversée du campus de la Doua
 La Voie Lyonnaise empruntera les aménagements cyclables récents existants (2021) en passant par l'avenue Einstein, la rue des Sports et la voie verte du boulevard Niels Bohr. Elle se raccordera ensuite à la voie verte existante en stabilisé au Sud du rond-point de la Feyssine, dont le revêtement inconfortable en sable stabilisé sera recouvert d'un enrobé lisse. Enfin, le long du boulevard Laurent Bonnevay, une nouvelle piste cyclable bidirectionnelle de 3m de large sera créée sur une des 3 voies de circulation côté Sud.
@@ -69,12 +68,10 @@ La concertation sur ce tronçon (hors tram T9) s'est tenue du 19/09 au 21/10/202
 [Voir le dossier de concertation](https://www.grandlyon.com/fileadmin/user_upload/media/pdf/grands-projets/concertation-reglementaire/20220916_voieslyonnaises_ligne5-nord-est_dossier.pdf)
 
 ### Pont Poincaré à Pont De Lattre de Tassigny
-Cette section est en tronçon commun avec la Voie Lyonnaise 1.  
-Se référer à [la page de la ligne](https://cyclopolis.fr/voie-lyonnaise-1) pour davantage d'informations.
+Cette section est en tronçon commun avec la :line-link{line=1}.
 
 ### Pont De Lattre de Tassigny à Pont Clémenceau
-Cette section est en tronçon commun avec la Voie Lyonnaise 4.  
-Se référer à [la page de la ligne](https://cyclopolis.fr/voie-lyonnaise-4) pour davantage d'informations.
+Cette section est en tronçon commun avec la :line-link{line=4}.
 
 ### Traversée de Vaise
 Aucune information publique n'existe à ce jour sur ce tronçon. Plusieurs variantes sont en cours d'étude par les services de la Métropole de Lyon.
@@ -138,8 +135,7 @@ La concertation publique sur ce tronçon s'est tenue du 15/05 au 19/06/2023.
 [Voir le dossier de concertation (p.56 à p.80)](https://jeparticipe.grandlyon.com/media/default/0001/01/1a4f5783222d6be99e21f46056a55be8f81dd87b.pdf)
 
 ### Gare d'Oullins à Pierre-Bénite Barrage
-Cette section est en tronçon commun avec la Voie Lyonnaise 3.  
-Se référer à [la page de la ligne](https://cyclopolis.fr/voie-lyonnaise-3) pour davantage d'informations.
+Cette section est en tronçon commun avec la :line-link{line=3}.
 
 ### Traversée Vallée de la Chimie
 La Voie Lyonnaise 5 empruntera :

--- a/content/voies-lyonnaises/ligne-8.md
+++ b/content/voies-lyonnaises/ligne-8.md
@@ -112,17 +112,15 @@ La concertation publique sur ce tronçon s'est tenue du 27/03 au 28/04/2023.
 [Voir le dossier de concertation](https://jeparticipe.grandlyon.com/media/default/0001/01/bd50d56d86221d7c4daf56f310abe3cb77aff211.pdf){:target="_blank"}
 
 ### Rue Pierre Audry<br/>Traversée de Saint-Just<br>Traversée de Saint-Jean
-Cette section est en tronçon commun avec la Voie Lyonnaise 12.  
-Se référer à [la page de la ligne](https://cyclopolis.fr/voie-lyonnaise-12) pour davantage d'informations.
+Cette section est en tronçon commun avec la :line-link{line=12}.
 
 ### Traversée de la Presqu'Île de Lyon
 Le projet devait faire un détour par le pôle d'échange de Perrache, via le quai Fulchiron et le pont Kitchener-Marchand puis remonter sur la rive droite du Rhône. Cependant, compte-tenu du fait que le projet "Apaisement Presqu'île" au sud de la Place Bellecour est prévu pour un mandat ultérieur, et que le trafic automobile et bus y est encore trop important, la Métropole de Lyon a décidé de reporter ce tracé dans un mandat ultérieur.
 
-Par conséquent, la Voie Lyonnaise 8 traversera la Presqu'île en tronc commun avec la ligne 12, via le pont Bonaparte et la place Bellecour.  
-Se référer à [la page de la ligne](https://cyclopolis.fr/voie-lyonnaise-12) pour davantage d'informations.
+Par conséquent, la Voie Lyonnaise 8 traversera la Presqu'île en tronc commun avec la :line-link{line=12}, via le pont Bonaparte et la place Bellecour.  
 
 ### Pont Université à Mermoz-Pinel
-Depuis la place Bellecour, la Voie Lyonnaise 8 descendra la rive droite du Rhône en tronc commun avec la ligne 6 jusqu'au pont de l'Université. Se référer à [la page de la ligne](https://cyclopolis.fr/voie-lyonnaise-6) pour davantage d'informations.
+Depuis la place Bellecour, la Voie Lyonnaise 8 descendra la rive droite du Rhône en tronc commun avec la :line-link{line=6} jusqu'au pont de l'Université.
 
 #### Pont de l'Université
 La Voie Lyonnaise 8 va totalement réaménager le pont qui sera débarrassé de ses vieilles bandes cyclables bilatérales sur trottoir. Les 4 voies de circulation actuelles seront réduites à 2, un couloir de bus à contre-sens sera créé et une large piste cyclable bidirectionnelle prendra place côté Sud.

--- a/content/voies-lyonnaises/ligne-9.md
+++ b/content/voies-lyonnaises/ligne-9.md
@@ -12,8 +12,7 @@ cover: https://cyclopolis.lavilleavelo.org/vl9/voie-lyonnaise-9.jpg
 ## Les tronçons (d'Ouest en Est)
 ### Traversée d'Oullins
 Depuis le quartier de Beaunant et la route de Brignais, la Voie Lyonnaise 9 traversera Oullins d'Ouest en Est.   
-Cette section est en tronçon commun avec la Voie Lyonnaise 5.  
-Se référer à [la page de la ligne](https://cyclopolis.fr/voie-lyonnaise-5) pour davantage d'informations.
+Cette section est en tronçon commun avec la :line-link{line=5}.
 
 ### Franchissement du Rhône
 La Voie Lyonnaise 9 passera des berges de l'Yzeron au parc de Gerland via une nouvelle passerelle mode actifs qui traversera la M7 et le Rhône. Elle fera 7m de large, avec une piste cyclable bidirectionnelle de 4m de large pour les cyclistes et un cheminement de 3m pour les piétons. Plusieurs scénarios de raccordement aux berges ont été proposés à la concertation, avec des rampes de 4 à 6% de pente.
@@ -36,11 +35,11 @@ Historiquement, deux pistes cyclables bilatérales avaient été peintes sur tro
 
 ### Jean Macé à Villeurbanne - St-Jean
 L'itinéraire est en tronçon commun avec d'autres Voies Lyonnaises :
- - [Voie Lyonnaise 8](https://cyclopolis.fr/voie-lyonnaise-8) sur rue Marc Bloch
- - [Voie Lyonnaise 7](https://cyclopolis.fr/voie-lyonnaise-7) sur rue Garibaldi de route de Vienne à rue Duquesne
- - [Voie Lyonnaise 4](https://cyclopolis.fr/voie-lyonnaise-4) sur rue Duquesne Est, boulevard des Belges et avenue Verguin
- - [Voie Lyonnaise 2](https://cyclopolis.fr/voie-lyonnaise-2) sur boulevard Stalingrad de Verguin à 11 Novembre
- - [Voie Lyonnaise 1](https://cyclopolis.fr/voie-lyonnaise-1) sur boulevard du 11 Novembre 1918, avenue Einstein et franchissement du canal de Jonage
+ - :line-link{line=8} sur rue Marc Bloch
+ - :line-link{line=7} sur rue Garibaldi de route de Vienne à rue Duquesne
+ - :line-link{line=4} sur rue Duquesne Est, boulevard des Belges et avenue Verguin
+ - :line-link{line=2} sur boulevard Stalingrad de Verguin à 11 Novembre
+ - :line-link{line=1} sur boulevard du 11 Novembre 1918, avenue Einstein et franchissement du canal de Jonage
 
 Se référer à la page de chaque ligne pour davantage d'informations.
 


### PR DESCRIPTION
Bonjour

De nombreuses pages décrivant les voies lyonnaises mentionnent des intersection avec d'autres voies.

Ce commit introduit un nouveau composant `LineLink` qui peut être utilisé inline dans le contenu des markdowns afin d'obtenir des liens de la couleur de la ligne ciblée.

### Avant:
```md
[Voie Lyonnaise 8](https://cyclopolis.fr/voie-lyonnaise-8) du boulevard du Valvert à l'avenue Victor Hugo
```
![image](https://github.com/benoitdemaegdt/voieslyonnaises/assets/39315/1f1c7817-2af0-4ba9-b5ae-1f1b8258f9ca)


### Après:
```md
:line-link{line=8} du boulevard du Valvert à l'avenue Victor Hugo
```
![image](https://github.com/benoitdemaegdt/voieslyonnaises/assets/39315/0fd48676-ac93-4f87-bf5d-44f8a4b72b27)
