### PR TITLE
feat(content): list lines on counters pages

### DIFF
--- a/content/compteurs/pont-de-la-mulatiere.json
+++ b/content/compteurs/pont-de-la-mulatiere.json
@@ -5,6 +5,7 @@
   "imageUrl": "https://source.unsplash.com/AoSAOV2Vtro",
   "idPdc": 100032516,
   "coordinates": [4.816630482673646, 45.731827222149356],
+  "lines": [6],
   "counts": [
     {
       "month": "2016/07/01",

--- a/content/compteurs/quai-augagneur.json
+++ b/content/compteurs/quai-augagneur.json
@@ -5,6 +5,7 @@
   "imageUrl": "https://source.unsplash.com/AoSAOV2Vtro",
   "idPdc": 100047691,
   "coordinates": [4.841102957725526, 45.76120974233474],
+  "lines": [1],
   "counts": [
     {
       "month": "2015/01/01",

--- a/content/compteurs/tunnel-croix-rousse.json
+++ b/content/compteurs/tunnel-croix-rousse.json
@@ -1,10 +1,11 @@
 {
   "name": "Tunnel de la Croix-Rousse",
-  "description": "Le compteur vélo du tunnel de la Croix Rousse est située à la sortie du tunnel, côté Saône. Il compte les passages des cyclistes dans les 2 sens de circulation.",
+  "description": "Le compteur vélo du tunnel de la Croix Rousse est situé à la sortie du tunnel, côté Saône. Il compte les passages des cyclistes dans les 2 sens de circulation.",
   "arrondissement": "Lyon 4",
   "imageUrl": "https://source.unsplash.com/AoSAOV2Vtro",
   "idPdc": 100030143,
   "coordinates": [4.813997, 45.77463],
+  "lines": [4, 5, 10],
   "counts": [
     {
       "month": "2016/04/01",

--- a/pages/compteurs/[slug].vue
+++ b/pages/compteurs/[slug].vue
@@ -19,11 +19,11 @@
       <p>{{ data.limitation }}</p>
     </template>
 
-    <template v-if="data.lines?.length > 0">
+    <template v-if="data && data.lines && data.lines.length > 0">
       <h2>Voies Lyonnaises mesurées par ce compteur</h2>
       <ul>
         <li v-for="line in data.lines" :key="line">
-          <LineLink :line="line" />
+          <LineLink :line="String(line)" />
         </li>
       </ul>
     </template>

--- a/pages/compteurs/[slug].vue
+++ b/pages/compteurs/[slug].vue
@@ -19,28 +19,37 @@
       <p>{{ data.limitation }}</p>
     </template>
 
+    <template v-if="data.lines?.length > 0">
+      <h2>Voies Lyonnaises mesurées par ce compteur</h2>
+      <ul>
+        <li v-for="line in data.lines" :key="line">
+          <LineLink :line="line" />
+        </li>
+      </ul>
+    </template>
+
     <h2>Source des données</h2>
     <p>Les données proviennent de <a href="https://data.eco-counter.com/ParcPublic/?id=3902#" target="_blank">data.eco-counter.com</a>.</p>
   </ContentFrame>
 </template>
 
 <script setup>
-const { path } = useRoute()
-const { withoutTrailingSlash } = useUrl()
+const { path } = useRoute();
+const { withoutTrailingSlash } = useUrl();
 
 const { data } = await useAsyncData(`compteur-${path}`, () => {
   return queryContent()
     .where({ _path: withoutTrailingSlash(path) })
-    .findOne()
-})
+    .findOne();
+});
 
 if (!data.value) {
-  const router = useRouter()
-  router.push({ path: '/404' })
+  const router = useRouter();
+  router.push({ path: '/404' });
 }
 
-const DESCRIPTION = `Compteur vélo ${data.value.name}`
-const IMAGE_URL = data.value.imageUrl
+const DESCRIPTION = `Compteur vélo ${data.value.name}`;
+const IMAGE_URL = data.value.imageUrl;
 useHead({
   meta: [
     // description
@@ -51,5 +60,5 @@ useHead({
     { hid: 'og:image', property: 'og:image', content: IMAGE_URL },
     { hid: 'twitter:image', name: 'twitter:image', content: IMAGE_URL }
   ]
-})
+});
 </script>


### PR DESCRIPTION
Bonsoir

Cet ajout permet de lister les Voies Lyonnaises sur lesquelles est placé un compteur.
Voici ce que ça rend pour le compteur à la sortie du tunnel de la Croix Rousse : 

![image](https://github.com/benoitdemaegdt/voieslyonnaises/assets/39315/ef7a3a3c-863c-4078-bfc5-25bb49fc4ccf)
