### PR TITLE
feat(charts): highlight max values in lvv-pink

### DIFF
--- a/components/chart/MonthComparison.vue
+++ b/components/chart/MonthComparison.vue
@@ -98,6 +98,9 @@ const years = computed(() => {
 });
 
 const chartOptions = computed(() => {
+  const countsValues = counts.value.map(count => count.count);
+  const max = Math.max(...countsValues);
+
   return {
     chart: { type: 'column' },
     title: { text: `Fréquentation cycliste en ${selectedMonth.value.name} - ${props.data.name}` },
@@ -109,15 +112,16 @@ const chartOptions = computed(() => {
       column: { pointPadding: 0.2, borderWidth: 0 },
       series: {
         dataLabels: {
-          enabled: true,
-          style: { color: '#152B68' }
+          enabled: true
         }
       }
     },
-    colors: ['#152B68'],
     series: [{
       name: 'fréquentation',
-      data: counts.value.map(count => count.count)
+      data: countsValues.map(y => {
+        const color = y === max ? '#C84271' : '#152B68';
+        return { y, color, dataLabels: { color } };
+      })
     }]
   };
 });

--- a/components/chart/MonthComparison.vue
+++ b/components/chart/MonthComparison.vue
@@ -85,25 +85,26 @@ const lastRecordMonth = new Date(lastRecord.month).getMonth();
 
 const selectedMonth = ref(months.find(month => month.value === lastRecordMonth));
 
+type Count = { month: string, count: number };
 const counts = computed(() => {
-  return props.data.counts.filter((count) => {
+  return props.data.counts.filter((count: Count) => {
     const date = new Date(count.month);
     const month = date.getMonth();
-    return month === selectedMonth.value.value;
-  }).sort((count1, count2) => count1.month - count2.month);
+    return month === selectedMonth.value!.value;
+  }).sort((count1: Count, count2: Count) => new Date(count1.month).getTime() - new Date(count2.month).getTime());
 });
 
 const years = computed(() => {
-  return counts.value.map(count => new Date(count.month).toLocaleString('fr-Fr', { month: 'long', year: 'numeric' }));
+  return counts.value.map((count: Count) => new Date(count.month).toLocaleString('fr-Fr', { month: 'long', year: 'numeric' }));
 });
 
 const chartOptions = computed(() => {
-  const countsValues = counts.value.map(count => count.count);
+  const countsValues = counts.value.map((count: Count) => count.count);
   const max = Math.max(...countsValues);
 
   return {
     chart: { type: 'column' },
-    title: { text: `Fréquentation cycliste en ${selectedMonth.value.name} - ${props.data.name}` },
+    title: { text: `Fréquentation cycliste en ${selectedMonth.value!.name} - ${props.data.name}` },
     credits: { enabled: false },
     legend: { enabled: false },
     xAxis: { categories: years.value },
@@ -118,7 +119,7 @@ const chartOptions = computed(() => {
     },
     series: [{
       name: 'fréquentation',
-      data: countsValues.map(y => {
+      data: countsValues.map((y: number) => {
         const color = y === max ? '#C84271' : '#152B68';
         return { y, color, dataLabels: { color } };
       })

--- a/components/chart/TotalByYear.vue
+++ b/components/chart/TotalByYear.vue
@@ -7,9 +7,15 @@
 </template>
 
 <script setup lang="ts">
-const props = defineProps({ data: { type: Object, required: true } })
+const props = defineProps({ data: { type: Object, required: true } });
 
-const years = [...new Set(props.data.counts.map(item => new Date(item.month).getFullYear()))].sort()
+const years = [...new Set(props.data.counts.map(item => new Date(item.month).getFullYear()))].sort();
+const countsValues = years.map((year) => {
+  return props.data.counts
+    .filter(item => new Date(item.month).getFullYear() === year)
+    .reduce((acc, item) => acc + item.count, 0);
+});
+const max = Math.max(...countsValues);
 
 const chartOptions = {
   chart: { type: 'column' },
@@ -22,18 +28,15 @@ const chartOptions = {
     column: { pointPadding: 0.2, borderWidth: 0 },
     series: {
       dataLabels: {
-        enabled: true,
-        style: { color: '#152B68' }
+        enabled: true
       }
     }
   },
-  colors: ['#152B68'],
   series: [{
     name: 'passages',
-    data: years.map((year) => {
-      return props.data.counts
-        .filter(item => new Date(item.month).getFullYear() === year)
-        .reduce((acc, item) => acc + item.count, 0)
+    data: countsValues.map(y => {
+      const color = y === max ? '#C84271' : '#152B68';
+      return { y, color, dataLabels: { color } };
     })
   }],
   responsive: {
@@ -51,5 +54,5 @@ const chartOptions = {
       }
     ]
   }
-}
+};
 </script>

--- a/components/chart/TotalByYear.vue
+++ b/components/chart/TotalByYear.vue
@@ -9,11 +9,12 @@
 <script setup lang="ts">
 const props = defineProps({ data: { type: Object, required: true } });
 
-const years = [...new Set(props.data.counts.map(item => new Date(item.month).getFullYear()))].sort();
+type Count = { month: string, count: number };
+const years = [...new Set(props.data.counts.map((item: Count) => new Date(item.month).getFullYear()))].sort();
 const countsValues = years.map((year) => {
   return props.data.counts
-    .filter(item => new Date(item.month).getFullYear() === year)
-    .reduce((acc, item) => acc + item.count, 0);
+    .filter((item: Count) => new Date(item.month).getFullYear() === year)
+    .reduce((acc: number, item: Count) => acc + item.count, 0);
 });
 const max = Math.max(...countsValues);
 


### PR DESCRIPTION
Bonjour

Cette PR poursuit ce qui a été fait avec l'ajout de badges roses "record" sur les compteurs de la page principale.

Sur les columns charts, la valeur maximale est désormais elle aussi en rose ce qui facilite le coup d’œil pour trouver quelle année à le record de passage lorsque les résultats sont serrés, comme par exemple sur septembre pour le pont Lafayette : 

![image](https://github.com/benoitdemaegdt/voieslyonnaises/assets/39315/2c1a7247-26b3-448f-87a8-475058b2fe1a)
