### PR TITLE
feat(map): add wip button on evolution page

### DIFF
--- a/composables/useMap.ts
+++ b/composables/useMap.ts
@@ -215,6 +215,10 @@ export const useMap = () => {
     if (sections.length === 0 && !map.getLayer('wip-sections')) {
       return;
     }
+    if (map.getSource('wip-sections')) {
+      map.getSource('wip-sections').setData({ type: 'FeatureCollection', features: sections });
+      return;
+    }
     map.addSource('wip-sections', {
       type: 'geojson',
       data: { type: 'FeatureCollection', features: sections }


### PR DESCRIPTION
Bonjour

Suite à l'inauguration de la VL2 Stalingrad hier, je me suis posé la question de quelles étaient les futures sections du réseau à pointer le bout de leur nez. La carte interactive propose déjà de les visualiser, mais elles sont "noyées" parmi le reste.

Cette PR propose d'ajouter un bouton "En travaux" à droite en bas de la page évolution. Il fonctionne comme les autres : on peut soit voir les sections en travaux en isolation ou combiner avec les années.

Quelques captures : 

2024 seules

![image](https://github.com/benoitdemaegdt/voieslyonnaises/assets/39315/4d7ff0ec-85db-4319-9085-dd44c2878315)

En travaux seules

![image](https://github.com/benoitdemaegdt/voieslyonnaises/assets/39315/7c6700ee-3e12-4e0b-a59d-b38cb03b81ec)

Toutes les années + en travaux

![image](https://github.com/benoitdemaegdt/voieslyonnaises/assets/39315/e30d0fa7-da04-43b2-ae35-9162dad843cc)

