### PR TITLE
feat: add optional anchor param for line-link

### DIFF
--- a/components/content/LineLink.vue
+++ b/components/content/LineLink.vue
@@ -1,5 +1,5 @@
 <template>
-  <NuxtLink :to="`/voie-lyonnaise-${line}`" :style="`color: ${color}; text-decoration-color: ${color};`">
+  <NuxtLink :to="`${href}`" :style="`color: ${color}; text-decoration-color: ${color};`">
     Voie Lyonnaise
     <span
       class="h-6 w-6 rounded-full inline-flex items-center justify-center text-white"
@@ -13,9 +13,14 @@
 <script setup>
 const { getLineColor } = useColors();
 
-const props = defineProps({
-  line: { type: String, required: true }
+const { line, anchor } = defineProps({
+  line: { type: String, required: true },
+  anchor: { type: String, default: '' }
 });
 
-const color = getLineColor(Number(props.line));
+const color = getLineColor(Number(line));
+
+const href = anchor
+  ? `/voie-lyonnaise-${line}#${anchor}`
+  : `/voie-lyonnaise-${line}`;
 </script>

--- a/content/voies-lyonnaises/ligne-1.md
+++ b/content/voies-lyonnaises/ligne-1.md
@@ -70,7 +70,7 @@ credit: Passagers des Villes / Métropole de Lyon.
 ::
 
 ### Stalingrad Nord
-Cette section est en tronçon commun avec la :line-link{line=2}.
+Cette section est en tronçon commun avec la :line-link{line=2 anchor="boulevard-stalingrad-nord"}.
 
 ### Cité Internationale à Halle Tony Garnier
 

--- a/content/voies-lyonnaises/ligne-2.md
+++ b/content/voies-lyonnaises/ligne-2.md
@@ -13,7 +13,7 @@ cover: https://cyclopolis.lavilleavelo.org/vl2/bd-vivier-merle.jpg
 ## Les tronçons (du Nord au Sud)
 
 ### Fontaines sur Saône à l'Île Barbe
-Cette section est en tronçon commun avec la :line-link{line=3}.
+Cette section est en tronçon commun avec la :line-link{line=3 anchor="neuville-sur-saône-à-saint-rambert"}.
 
 ### Traversée du Plateau Nord
 


### PR DESCRIPTION
Bonjour

`line-link` accepte désormais un paramètre `anchor` optionnel. C'est plus pratique depuis que les ancres ont été ajoutées aux headings.

J'ai ajouté deux exemples d'utilisation dans cette PR. Ajuster les autres liens sur les pages des VL ou des News pourra etre fait au fil de l'eau dans des PR futures.

Exemple VL1 vers VL2

```md
### Stalingrad Nord
Cette section est en tronçon commun avec la :line-link{line=2 anchor="boulevard-stalingrad-nord"}.
```