### PR TITLE
feat(map): add sections toggles in legend

### DIFF
--- a/components/LegendModal.vue
+++ b/components/LegendModal.vue
@@ -27,7 +27,7 @@
             </div>
             <div>
               <label>
-                <input v-model="layers.planned" type="checkbox">
+                <input v-model="legendItems.planned.isEnable" type="checkbox">
                 prévu pour 2026
               </label>
             </div>
@@ -37,7 +37,7 @@
             </div>
             <div>
               <label>
-                <input v-model="layers.done" type="checkbox">
+                <input v-model="legendItems.done.isEnable" type="checkbox">
                 terminé
               </label>
             </div>
@@ -51,7 +51,7 @@
             </div>
             <div>
               <label>
-                <input v-model="layers.wip" type="checkbox">
+                <input v-model="legendItems.wip.isEnable" type="checkbox">
                 en travaux
               </label>
             </div>
@@ -63,18 +63,20 @@
             </div>
             <div>
               <label>
-                <input v-model="layers.unknown" type="checkbox">
+                <input v-model="legendItems.unknown.isEnable" type="checkbox">
                 linéaire inconnu
               </label>
             </div>
 
             <div class="my-auto rounded-md border-gray-500 border relative">
               <div class="h-1 bg-white" />
-              <div class="text-lvv-blue-600 font-bold leading-none absolute -top-2 leading-none">x x x x x</div>
+              <div class="text-lvv-blue-600 font-bold leading-none absolute -top-2 leading-none">
+                x x x x x
+              </div>
             </div>
             <div>
               <label>
-                <input v-model="layers.postponed" type="checkbox">
+                <input v-model="legendItems.postponed.isEnable" type="checkbox">
                 reporté après 2026
               </label>
             </div>
@@ -85,7 +87,7 @@
   </Dialog>
 </template>
 
-<script setup>
+<script setup lang="ts">
 import { Dialog, DialogPanel, DialogTitle } from '@headlessui/vue';
 
 const isOpen = ref(false);
@@ -101,9 +103,39 @@ defineExpose({
   openModal
 });
 
-const { layers } = defineProps({
-  layers: { type: Object, required: true }
+const legendItems = ref({
+  planned: {
+    isEnable: true,
+    statuses: ['planned', 'variante']
+  },
+  done: {
+    isEnable: true,
+    statuses: ['done']
+  },
+  postponed: {
+    isEnable: true,
+    statuses: ['postponed', 'variante-postponed']
+  },
+  unknown: {
+    isEnable: true,
+    statuses: ['unknown']
+  },
+  wip: {
+    isEnable: true,
+    statuses: ['wip']
+  }
 });
+
+const emit = defineEmits(['update:visibleStatuses']);
+
+watch(legendItems, () => {
+  const visibleStatuses = Object.values(legendItems.value)
+    .filter(item => item.isEnable)
+    .flatMap(item => item.statuses);
+
+  emit('update:visibleStatuses', visibleStatuses);
+}, { deep: true });
+
 </script>
 
 <style>

--- a/components/LegendModal.vue
+++ b/components/LegendModal.vue
@@ -13,7 +13,9 @@
         >
           <Icon name="mdi:close" class="h-6 w-6" aria-hidden="true" />
         </button>
-        <DialogTitle class="text-lg font-medium leading-6 text-gray-900"> Légende </DialogTitle>
+        <DialogTitle class="text-lg font-medium leading-6 text-gray-900">
+          Légende
+        </DialogTitle>
         <div class="mt-2">
           <div class="grid grid-cols-[64px_1fr] gap-x-4">
             <div class="my-auto rounded-md border-gray-500 border">
@@ -23,12 +25,22 @@
                 </div>
               </div>
             </div>
-            <div>prévu pour 2026</div>
+            <div>
+              <label>
+                <input v-model="layers.planned" type="checkbox">
+                prévu pour 2026
+              </label>
+            </div>
 
             <div class="my-auto rounded-md border-gray-500 border">
               <div class="h-1 bg-lvv-blue-600" />
             </div>
-            <div>terminé</div>
+            <div>
+              <label>
+                <input v-model="layers.done" type="checkbox">
+                terminé
+              </label>
+            </div>
 
             <div class="my-auto rounded-md border-gray-500 border">
               <div class="h-1 relative">
@@ -37,20 +49,35 @@
                 </div>
               </div>
             </div>
-            <div>en travaux</div>
+            <div>
+              <label>
+                <input v-model="layers.wip" type="checkbox">
+                en travaux
+              </label>
+            </div>
 
             <div class="my-auto h-4 rounded-md bg-lvv-blue-600 opacity-20 px-1">
               <div class="flex items-center justify-center h-full">
                 <div class="h-1 w-full rounded-md border-2 border-gray-500" />
               </div>
             </div>
-            <div>linéaire inconnu</div>
+            <div>
+              <label>
+                <input v-model="layers.unknown" type="checkbox">
+                linéaire inconnu
+              </label>
+            </div>
 
             <div class="my-auto rounded-md border-gray-500 border relative">
               <div class="h-1 bg-white" />
               <div class="text-lvv-blue-600 font-bold leading-none absolute -top-2 leading-none">x x x x x</div>
             </div>
-            <div>reporté après 2026</div>
+            <div>
+              <label>
+                <input v-model="layers.postponed" type="checkbox">
+                reporté après 2026
+              </label>
+            </div>
           </div>
         </div>
       </DialogPanel>
@@ -72,6 +99,10 @@ function openModal() {
 
 defineExpose({
   openModal
+});
+
+const { layers } = defineProps({
+  layers: { type: Object, required: true }
 });
 </script>
 

--- a/components/Map.vue
+++ b/components/Map.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="relative">
-    <LegendModal ref="legendModalComponent" :layers="layers" />
+    <LegendModal ref="legendModalComponent" @update:visible-statuses="refreshVisibleStatuses" />
     <div id="map" class="rounded-lg h-full w-full" />
     <img
       v-if="options.logo"
@@ -56,39 +56,16 @@ const {
   fitBounds
 } = useMap();
 
-const layers = ref({
-  done: true,
-  planned: true,
-  postponed: true,
-  unknown: true,
-  wip: true
-});
-
+const visibleStatuses = ref(['planned', 'variante', 'done', 'postponed', 'variante-postponed', 'unknown', 'wip']);
 const features = computed(() => {
   return (props.features ?? []).filter(feature => {
-    for (const [layer, enabled] of Object.entries(layers.value)) {
-      if (!enabled) {
-        switch (feature.properties.status) {
-          case 'variante':
-            if (layer === 'planned') {
-              return false;
-            }
-            break;
-
-          case 'variante-postponed':
-            if (layer === 'postponed') {
-              return false;
-            }
-            break;
-
-          case layer:
-            return false;
-        }
-      }
-    }
-    return true;
+    return visibleStatuses.value.includes(feature.properties.status);
   });
 });
+
+function refreshVisibleStatuses(newVisibleStatuses) {
+  visibleStatuses.value = newVisibleStatuses;
+}
 
 onMounted(() => {
   const map = new Map({

--- a/composables/useMap.ts
+++ b/composables/useMap.ts
@@ -5,7 +5,7 @@ type LineStringFeature = {
   properties: {
     line: number;
     name: string;
-    status: string;
+    status: 'done' | 'wip' | 'planned' | 'postponed' | 'unknown' | 'variante' | 'variante-postponed';
     doneAt?: string;
   };
   geometry: {
@@ -104,7 +104,7 @@ function getCrossIconUrl(color: string): string {
 }
 
 function groupFeaturesByColor(features: ColoredLineStringFeature[]) {
-  const featuresByColor: any = {};
+  const featuresByColor: Record<string, Feature[]> = {};
   for (const feature of features) {
     const color = feature.properties.color;
 
@@ -146,21 +146,28 @@ export const useMap = () => {
     };
   }
 
+  function upsertMapSource(map: Map, sourceName: string, features: Feature[]) {
+    const source = map.getSource(sourceName) as GeoJSONSource;
+    if (source) {
+      source.setData({ type: 'FeatureCollection', features });
+      return true;
+    }
+    map.addSource(sourceName, {
+      type: 'geojson',
+      data: { type: 'FeatureCollection', features }
+    });
+    return false;
+  }
+
   function plotUnderlinedSections({ map, features }: { map: Map; features: LineStringFeature[] }) {
     const sections = features.map((feature, index) => ({ id: index, ...feature }));
 
     if (sections.length === 0 && !map.getLayer('highlight')) {
       return;
     }
-    const source = map.getSource('all-sections') as GeoJSONSource;
-    if (source) {
-      source.setData({ type: 'FeatureCollection', features: sections });
+    if (upsertMapSource(map, 'all-sections', sections)) {
       return;
     }
-    map.addSource('all-sections', {
-      type: 'geojson',
-      data: { type: 'FeatureCollection', features: sections }
-    });
 
     map.addLayer({
       id: 'highlight',
@@ -226,15 +233,10 @@ export const useMap = () => {
     if (sections.length === 0 && !map.getLayer('done-sections')) {
       return;
     }
-    const source = map.getSource('done-sections') as GeoJSONSource;
-    if (source) {
-      source.setData({ type: 'FeatureCollection', features: sections });
+    if (upsertMapSource(map, 'done-sections', sections)) {
       return;
     }
-    map.addSource('done-sections', {
-      type: 'geojson',
-      data: { type: 'FeatureCollection', features: sections }
-    });
+
     map.addLayer({
       id: 'done-sections',
       type: 'line',
@@ -252,15 +254,10 @@ export const useMap = () => {
     if (sections.length === 0 && !map.getLayer('wip-sections')) {
       return;
     }
-    const source = map.getSource('wip-sections') as GeoJSONSource;
-    if (source) {
-      source.setData({ type: 'FeatureCollection', features: sections });
+    if (upsertMapSource(map, 'wip-sections', sections)) {
       return;
     }
-    map.addSource('wip-sections', {
-      type: 'geojson',
-      data: { type: 'FeatureCollection', features: sections }
-    });
+
     map.addLayer({
       id: 'wip-sections',
       type: 'line',
@@ -305,10 +302,10 @@ export const useMap = () => {
     if (sections.length === 0 && !map.getLayer('planned-sections')) {
       return;
     }
-    map.addSource('planned-sections', {
-      type: 'geojson',
-      data: { type: 'FeatureCollection', features: sections }
-    });
+    if (upsertMapSource(map, 'planned-sections', sections)) {
+      return;
+    }
+
     map.addLayer({
       id: 'planned-sections',
       type: 'line',
@@ -327,10 +324,10 @@ export const useMap = () => {
     if (sections.length === 0 && !map.getLayer('variante-sections')) {
       return;
     }
-    map.addSource('variante-sections', {
-      type: 'geojson',
-      data: { type: 'FeatureCollection', features: sections }
-    });
+    if (upsertMapSource(map, 'variante-sections', sections)) {
+      return;
+    }
+
     map.addLayer({
       id: 'variante-sections',
       type: 'line',
@@ -369,10 +366,10 @@ export const useMap = () => {
     if (sections.length === 0 && !map.getLayer('variante-postponed-sections')) {
       return;
     }
-    map.addSource('variante-postponed-sections', {
-      type: 'geojson',
-      data: { type: 'FeatureCollection', features: sections }
-    });
+    if (upsertMapSource(map, 'variante-postponed-sections', sections)) {
+      return;
+    }
+
     map.addLayer({
       id: 'variante-postponed-sections',
       type: 'line',
@@ -411,10 +408,10 @@ export const useMap = () => {
     if (sections.length === 0 && !map.getLayer('unknown-sections')) {
       return;
     }
-    map.addSource('unknown-sections', {
-      type: 'geojson',
-      data: { type: 'FeatureCollection', features: sections }
-    });
+    if (upsertMapSource(map, 'unknown-sections', sections)) {
+      return;
+    }
+
     map.addLayer({
       id: 'unknown-sections',
       type: 'line',
@@ -469,15 +466,17 @@ export const useMap = () => {
     const sections = features.filter(feature => feature.properties.status === 'postponed');
 
     if (sections.length === 0) {
+      for (let line = 1; line <= 12; line++) {
+        upsertMapSource(map, `postponed-sections-${getLineColor(line)}`, []);
+      }
       return;
     }
 
     const featuresByColor = groupFeaturesByColor(sections);
     for (const [color, sameColorFeatures] of Object.entries(featuresByColor)) {
-      map.addSource(`postponed-sections-${color}`, {
-        type: 'geojson',
-        data: { type: 'FeatureCollection', features: sameColorFeatures }
-      });
+      if (upsertMapSource(map, `postponed-sections-${color}`, sameColorFeatures as Feature[])) {
+        continue;
+      }
 
       const iconUrl = getCrossIconUrl(color);
       map.loadImage(iconUrl, (error?: Error | null, image?: any) => {
@@ -531,13 +530,10 @@ export const useMap = () => {
     if (perspectives.length === 0) {
       return;
     }
-    map.addSource('perspectives', {
-      type: 'geojson',
-      data: {
-        type: 'FeatureCollection',
-        features: perspectives
-      }
-    });
+
+    if (upsertMapSource(map, 'perspectives', perspectives)) {
+      return;
+    }
 
     map.loadImage('/icons/camera.png', (error?: Error | null, image?: any) => {
       if (error) {


### PR DESCRIPTION
Bonjour

Cette PR apporte la possibilité d'afficher ou masquer les différents type de sections de VL depuis la légende.

Des captures d'écran pour commencer: 

Uniquement les sections en travaux:

![image](https://github.com/benoitdemaegdt/voieslyonnaises/assets/39315/297aa28b-7361-429f-8698-4d0626ade342)

Sections terminées et reportées:

![image](https://github.com/benoitdemaegdt/voieslyonnaises/assets/39315/a0166ac4-01e2-4931-ba3d-3d3919fae6e7)

Pour de futures PRs, il y a encore du boulot pour rendre l'UX plus sympa:

- comme indiqué par Thibaut, ce bouton "Légende" pourrait se renommer en "Layers" avec un icone différent du "i" actuel.
- les cases à cocher méritent certainement d’être stylées (blue LVV…).
- avoir cette modal en plein milieu de l'écran masque un peu ce qu'on est en train de faire lorsqu'on coche et décoche les cases (surtout en faible zoom), donc il faudrait peut être que ça devienne un panneau latéral rétractable à souhait.
- au sein de cette légende on pourrait bien entendu ajouter d'autres options comme les typologies, les compteurs etc…

Ceci dit, je pense que cette première étape peut être mergée sans attendre la suite (enfin après la review bien sur), car meme si comme décrit ci dessus ce n'est pas encore parfait, en tout cas ce n'a dégrade pas ce qu'il y a actuellement, ce n'est que du +. Et en terme de volume de code changé ce n'est pas très disruptif.
