### PR TITLE
feat: add StreetViewLink component

### DIFF
--- a/components/content/ContentImage.vue
+++ b/components/content/ContentImage.vue
@@ -14,6 +14,9 @@
     <div v-if="credit" class="text-base text-center italic">
       Crédit image : {{ credit }}
     </div>
+    <div v-if="streetView">
+      <StreetViewLink :params="streetView" />
+    </div>
   </figure>
 </template>
 
@@ -21,6 +24,7 @@
 defineProps({
   imageUrl: { type: String, required: true },
   caption: { type: String, required: false },
-  credit: { type: String, required: false }
+  credit: { type: String, required: false },
+  streetView: { type: String, required: false }
 });
 </script>

--- a/components/content/StreetViewLink.vue
+++ b/components/content/StreetViewLink.vue
@@ -1,0 +1,54 @@
+<template>
+  <a class="text-sm" :href="url.toString()">Voir sur Google Street View</a>
+</template>
+
+<script setup>
+/**
+ * The params string corresponds to what's visible in the first
+ * part of the path URL of Google Street View
+ * @example 45.7727386,4.810561,3a,75y,180h,90t
+ * - latitude 45.7727386
+ * - longitude 4.810561
+ * - fov 75
+ * - heading 180
+ * - pitch 90
+ */
+const { params } = defineProps({
+  params: { type: String, required: true }
+});
+
+const url = new URL('https://www.google.com/maps/@?api=1&map_action=pano');
+
+const [latitude, longitude, , fov, heading, pitch] = params.split(',');
+
+url.searchParams.append('viewpoint', `${latitude},${longitude}`);
+
+/**
+ * heading: Indicates the compass heading of the camera in degrees clockwise from North.
+ * Accepted values are from -180 to 360 degrees.
+ * If omitted, a default heading is chosen based on the viewpoint (if specified) of the query and the actual location of the image.
+ */
+if (heading) {
+  url.searchParams.append('heading', heading.slice(0, -1));
+}
+/**
+ * pitch: Specifies the angle, up or down, of the camera.
+ * The pitch is specified in degrees from -90 to 90.
+ * Positive values will angle the camera up, while negative values will angle the camera down.
+ * The default pitch of 0 is set based on on the position of the camera when the image was captured.
+ * Because of this, a pitch of 0 is often, but not always, horizontal.
+ * For example, an image taken on a hill will likely exhibit a default pitch that is not horizontal.
+ */
+if (pitch) {
+  url.searchParams.append('pitch', Number(pitch.slice(0, -1)) - 90);
+}
+/**
+ * fov: Determines the horizontal field of view of the image.
+ * The field of view is expressed in degrees, with a range of 10 - 100.
+ * It defaults to 90. When dealing with a fixed-size viewport, the field of view is considered the zoom level,
+ * with smaller numbers indicating a higher level of zoom.
+ */
+if (fov) {
+  url.searchParams.append('fov', fov.slice(0, -1));
+}
+</script>

--- a/content/voies-lyonnaises/ligne-1.md
+++ b/content/voies-lyonnaises/ligne-1.md
@@ -166,6 +166,7 @@ Enfin, sur la rue Charles Plasse, il s'agira d'une piste de 3m de large côté S
 imageUrl: https://cyclopolis.lavilleavelo.org/vl1/rue-charles-plasse.jpeg
 caption: Aperçu de la Voie Lyonnaise 1 le long du tram T10 - rue Charles Plasse (Saint-Fons)
 credit: Ilex / SYTRAL Mobilité
+streetView: 45.7088794,4.8538795,3a,75y,320h,90t
 ---
 ::
 

--- a/content/voies-lyonnaises/ligne-3.md
+++ b/content/voies-lyonnaises/ligne-3.md
@@ -94,6 +94,7 @@ Cette portion doit faire l'objet d'un réaménagement majeur, avec la mise en se
 imageUrl: https://cyclopolis.lavilleavelo.org/vl3/quai-arloing.jpg
 caption: Aperçu de la Voie Lyonnaise 3 - Quai Arloing (Lyon 9)
 credit: Métropole de Lyon
+streetView: 45.7727386,4.810561,3a,75y,163.15h,90t
 ---
 ::
 

--- a/content/voies-lyonnaises/ligne-7.md
+++ b/content/voies-lyonnaises/ligne-7.md
@@ -85,6 +85,7 @@ Entre la station BP et la rue Denfert-Rochereau, la même piste cyclable sur tro
 imageUrl: https://cyclopolis.lavilleavelo.org/vl7/bd-des-canuts.png
 caption: Aperçu de la Voie Lyonnaise 7 - Boulevard des Canuts (Lyon 4)
 credit: Métropole de Lyon
+streetView: 45.7804136,4.8275125,3a,75y,37.09h,90t
 ---
 ::
 


### PR DESCRIPTION
Bonjour

On en avait parlé brièvement ensemble, je pense qu'on est tous assez friand de l'effet "avant / après" en photo pour rendre les évolutions du réseau plus tangible.

Ainsi je vous propose l'ajout de liens vers Google Street View. Il ne s'agit pas d'une intégration poussée où une iframe serait directement intégrée au site, car cela nous ferait entrer sur le terrain des API keys, des quotas, des personnes qui ne souhaitent pas se faire tracker par big G…

Ici la solution est plus pragmatique. Il suffit d'ajouter un nouveau paramètre facultatif `streetView` en plus de la légende des photos au sein des pages.

J'ai fait 3 exemples dans cette PR. Si je prends le cas de la VL3 (Quai d'Arloing), voila comment ça marche: 

```
:content-image
---
imageUrl: https://cyclopolis.lavilleavelo.org/vl3/quai-arloing.jpg
caption: Aperçu de la Voie Lyonnaise 3 - Quai Arloing (Lyon 9)
credit: Métropole de Lyon
streetView: 45.7727386,4.810561,3a,75y,163.15h,90t
---
```

Le param `45.7727386,4.810561,3a,75y,163.15h,90t` est extrait depuis l'URL lorsqu'on visite Google Street View manuellement:

![image](https://github.com/benoitdemaegdt/voieslyonnaises/assets/39315/0da30733-513a-4900-b225-cd6882e9dbf1)

L'objectif est que cela soit facile et ne demande qu'un "bête" copier-coller de cette section de l'URL pour rapidement agrémenter les prises de vues.

Ce qui donne donc:

![image](https://github.com/benoitdemaegdt/voieslyonnaises/assets/39315/5f76f669-820d-49b3-9256-a4474533e3b6)

(si ce lien "Voir sur Google Street View" est trop proéminent, trop centré etc… on peut tout à faire revoir la façon de le faire apparaître)

Et lorsqu'on clique, dans une nouvel onglet s'ouvre https://www.google.com/maps/@?api=1&map_action=pano&viewpoint=45.7727386%2C4.810561&heading=163.15&pitch=0&fov=75: 

![image](https://github.com/benoitdemaegdt/voieslyonnaises/assets/39315/fba85a45-8e7b-4cb0-a99d-c6cc85a5ca4e)

Pour le moment j'ai choisi d'intégrer ce nouveau composant `StreetViewLink` uniquement sous les photos, mais on pourrait bien entendu très bien l'imaginer ailleurs, comme dans les popups de perspective sur la carte interactive ou même dans les articles de news.