### PR TITLE
Evolution map enhancements

### DIFF
--- a/composables/useMap.ts
+++ b/composables/useMap.ts
@@ -660,18 +660,17 @@ export const useMap = () => {
   }
 
   function plotFeatures({ map, features }: { map: Map; features: Feature[] }) {
-    const lineStringFeatures = features.filter(isLineStringFeature);
-    if (lineStringFeatures.length) {
-      const features = lineStringFeatures.sort(sortByLine).map(addLineColor);
-      plotUnderlinedSections({ map, features });
-      plotDoneSections({ map, features });
-      plotPlannedSections({ map, features });
-      plotVarianteSections({ map, features });
-      plotVariantePostponedSections({ map, features });
-      plotWipSections({ map, features });
-      plotUnknownSections({ map, features });
-      plotPostponedSections({ map, features });
-    }
+    const lineStringFeatures = features.filter(isLineStringFeature).sort(sortByLine).map(addLineColor);
+
+    plotUnderlinedSections({ map, features: lineStringFeatures });
+    plotDoneSections({ map, features: lineStringFeatures });
+    plotPlannedSections({ map, features: lineStringFeatures });
+    plotVarianteSections({ map, features: lineStringFeatures });
+    plotVariantePostponedSections({ map, features: lineStringFeatures });
+    plotWipSections({ map, features: lineStringFeatures });
+    plotUnknownSections({ map, features: lineStringFeatures });
+    plotPostponedSections({ map, features: lineStringFeatures });
+
     plotPerspective({ map, features });
     plotCompteurs({ map, features });
   }

--- a/pages/evolution/index.vue
+++ b/pages/evolution/index.vue
@@ -7,7 +7,7 @@
       <div class="py-2 px-5 md:px-8 text-white bg-lvv-blue-600 font-semibold text-base">
         {{ doneDistance }} km de Voies Lyonnaises réalisés
       </div>
-      <div class="py-5 px-5 md:px-8 grid grid-cols-3 gap-3 sm:grid-cols-6">
+      <div class="py-5 px-5 md:px-8 grid grid-cols-3 gap-3 sm:grid-cols-5">
         <div
           v-for="year in years"
           :key="year.label"


### PR DESCRIPTION
Bonjour, cette PR pour apporter quelques corrections mineures à la carte d'évolution du réseau cyclable.

Une incohérence apparaissait lorsque l'on désélectionnait toutes les options de la toolbar en bas de la page : le compteur indique bien 0km construits, mais les tracés de la dernière année sélectionnée apparaissent toujours.

![evo1](https://github.com/benoitdemaegdt/voieslyonnaises/assets/44813937/c115442c-7a25-446f-b4ff-2ae9c0a92832)

Une condition empêchait la mise à jour de la carte dans le cas où l'on n'avait plus de tracés.

Également une correction du nombre de colonnes affichées dans la grille de cette toolbar pour qu'elle prenne toute la longueur de la fenêtre, et ainsi obtenir le résultat suivant.

![evo2](https://github.com/benoitdemaegdt/voieslyonnaises/assets/44813937/4514fb5e-8de4-43c9-ba57-dd9ce773141c)

Au passage, merci pour votre travail sur ce fabuleux outil, que je découvre à peine !