### PR TITLE
refactor: mutualize scattered types

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,7 @@
     "arrow-parens": "off",
     "semi": ["error", "always"],
     "space-before-function-paren": ["error", "never"],
-    "no-template-curly-in-string": "off"
+    "no-template-curly-in-string": "off",
+    "vue/multi-word-component-names": "off"
   }
 }

--- a/components/Map.vue
+++ b/components/Map.vue
@@ -13,7 +13,7 @@
   </div>
 </template>
 
-<script setup>
+<script setup lang="ts">
 import { createApp, defineComponent, h, Suspense } from 'vue';
 import { Map, AttributionControl, GeolocateControl, NavigationControl, Popup } from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
@@ -24,19 +24,10 @@ import ShrinkControl from '@/maplibre/ShrinkControl';
 import LineTooltip from '~/components/tooltips/LineTooltip.vue';
 import CounterTooltip from '~/components/tooltips/CounterTooltip.vue';
 import PerspectiveTooltip from '~/components/tooltips/PerspectiveTooltip.vue';
+import { type Feature, isLineStringFeature } from '~/types';
 
 // const config = useRuntimeConfig();
 // const maptilerKey = config.public.maptilerKey;
-
-const props = defineProps({
-  features: { type: Array, required: true },
-  options: {
-    type: Object,
-    required: false,
-    default: () => ({})
-  }
-});
-
 const defaultOptions = {
   logo: true,
   legend: true,
@@ -46,6 +37,11 @@ const defaultOptions = {
   shrink: false,
   onShrinkControlClick: () => { }
 };
+
+const props = defineProps<{
+  features: Feature[];
+  options: typeof defaultOptions;
+}>();
 
 const options = { ...defaultOptions, ...props.options };
 
@@ -172,7 +168,7 @@ onMounted(() => {
       const { line, name } = layers[0].properties;
       // take care layers[0].geometry is truncated (to fit tile size). We need to find the full feature.
       const feature = props.features
-        .filter(feature => feature.geometry.type === 'LineString')
+        .filter(isLineStringFeature)
         .find(feature => feature.properties.line === line && feature.properties.name === name);
       const lines = feature.properties.id
         ? [...new Set(layers.filter(f => f.properties.id === feature.properties.id).map(f => f.properties.line))]

--- a/components/ProgressBar.vue
+++ b/components/ProgressBar.vue
@@ -21,12 +21,14 @@
   </div>
 </template>
 
-<script setup>
+<script setup lang="ts">
+import type { Geojson } from '~/types';
+
 const { getStats, displayPercent } = useStats();
 
-const { voies } = defineProps({
-  voies: { type: Array, required: true }
-});
+const { voies } = defineProps<{
+  voies: Geojson[];
+}>();
 
 const stats = getStats(voies);
 </script>

--- a/components/Stats.vue
+++ b/components/Stats.vue
@@ -18,13 +18,14 @@
   </div>
 </template>
 
-<script setup>
+<script setup lang="ts">
+import type { Geojson } from '~/types';
 const { getStats, displayDistanceInKm, displayPercent } = useStats();
 
-const { voies, precision } = defineProps({
-  voies: { type: Array, required: true },
-  precision: { type: Number, default: 0 }
-});
+const { voies, precision } = defineProps<{
+  voies: Geojson[];
+  precision?: number;
+}>();
 
 const stats = getStats(voies);
 </script>

--- a/components/tooltips/CounterTooltip.vue
+++ b/components/tooltips/CounterTooltip.vue
@@ -52,23 +52,10 @@
 </template>
 
 <script setup lang="ts">
+import type { CompteurFeature } from '~/types';
+
 const { feature } = defineProps<{
-  feature: {
-    type: 'Feature',
-    properties: {
-      type: 'compteur-velo' | 'compteur-voiture',
-      name: string,
-      link: string,
-      counts: {
-        month: string,
-        count: number
-      }[]
-    },
-    geometry: {
-      type: 'Point',
-      coordinates: [number, number],
-    }
-  }
+  feature: CompteurFeature
 }>();
 
 const title = computed(() => feature.properties.type === 'compteur-velo' ? 'Compteur vélo' : 'Compteur voiture');

--- a/components/tooltips/LineTooltip.vue
+++ b/components/tooltips/LineTooltip.vue
@@ -55,28 +55,13 @@
 </template>
 
 <script setup lang="ts">
+import type { LineStringFeature } from '~/types';
+
 const { getLineColor } = useColors();
 const { getDistance } = useStats();
 
-type Status = 'done' | 'wip' | 'planned' | 'postponed' | 'variante';
-type Properties = {
-  id?: string;
-  line: number;
-  name: string;
-  status: Status;
-  doneAt?: string;
-  link?: string;
-};
-
 const { feature, lines } = defineProps<{
-  feature: {
-    type: string;
-    properties: Properties;
-    geometry: {
-      type: string;
-      coordinates: number[][];
-    };
-  }
+  feature: LineStringFeature;
   lines: number[];
 }>();
 
@@ -84,7 +69,7 @@ const title = computed(() => {
   return lines.length > 1 ? 'Voies Lyonnaises' : 'Voie Lyonnaise';
 });
 
-function getSectionDetailsUrl(properties: Properties): string {
+function getSectionDetailsUrl(properties: LineStringFeature['properties']): string {
   if (properties.link) {
     return properties.link;
   }
@@ -101,7 +86,7 @@ function getDoneAtText(doneAt: string): string {
   return `le ${doneAt}`;
 }
 
-function getStatus(properties: Properties): { label: string, class: string; date?: string } {
+function getStatus(properties: LineStringFeature['properties']): { label: string, class: string; date?: string } {
   const statusMapping = {
     done: {
       label: 'terminé',

--- a/components/tooltips/PerspectiveTooltip.vue
+++ b/components/tooltips/PerspectiveTooltip.vue
@@ -16,23 +16,12 @@
 </template>
 
 <script setup lang="ts">
+import type { PerspectiveFeature } from '~/types';
+
 const { getLineColor } = useColors();
 
 const { feature } = defineProps<{
-  feature: {
-    type: 'Feature';
-    properties: {
-      type: 'perspective';
-      name?: string;
-      line: string;
-      imgUrl: string;
-    };
-    geometry: {
-      type: 'Point';
-      coordinates: [number, number];
-    };
-  }
-
+  feature: PerspectiveFeature
 }>();
 
 const color = getLineColor(Number(feature.properties.line));

--- a/composables/useMap.ts
+++ b/composables/useMap.ts
@@ -1,70 +1,5 @@
 import { GeoJSONSource, LngLatBounds, Map } from 'maplibre-gl';
-
-type LineStringFeature = {
-  type: 'Feature';
-  properties: {
-    line: number;
-    name: string;
-    status: string;
-    doneAt?: string;
-  };
-  geometry: {
-    type: 'LineString';
-    coordinates: [number, number][];
-  };
-};
-
-type ColoredLineStringFeature = LineStringFeature & { properties: { color: string } };
-
-type PerspectiveFeature = {
-  type: 'Feature';
-  properties: {
-    type: 'perspective';
-    line: number;
-    name: string;
-  };
-  geometry: {
-    type: 'Point';
-    coordinates: [number, number];
-  };
-};
-
-type CompteurFeature = {
-  type: 'Feature';
-  properties: {
-    type: 'compteur';
-    line: number;
-    name: string;
-    counts?: any[];
-    /**
-     * z-index like
-     */
-    circleSortKey?: number;
-    circleRadius?: number;
-    circleStrokeWidth?: number;
-  };
-  geometry: {
-    type: 'Point';
-    coordinates: [number, number];
-  };
-};
-
-type PointFeature = PerspectiveFeature | CompteurFeature;
-
-type Feature = LineStringFeature | PointFeature;
-
-type Compteur = {
-  name: string;
-  _path: string;
-  description: string;
-  idPdc: number;
-  coordinates: [number, number];
-  lines: number[];
-  counts: Array<{
-    month: string;
-    count: number;
-  }>;
-};
+import { isPerspectiveFeature, type ColoredLineStringFeature, type Compteur, type Feature, type LineStringFeature, isCompteurFeature, isLineStringFeature, isPointFeature } from '../types';
 
 // features plotted last are on top
 const sortOrder = [1, 3, 2, 4, 5, 6, 7, 12, 8, 9, 10, 11].reverse();
@@ -115,22 +50,6 @@ function groupFeaturesByColor(features: ColoredLineStringFeature[]) {
     }
   }
   return featuresByColor;
-}
-
-function isLineStringFeature(feature: Feature): feature is LineStringFeature {
-  return feature.geometry.type === 'LineString';
-}
-
-function isPointFeature(feature: Feature): feature is PointFeature {
-  return feature.geometry.type === 'Point';
-}
-
-function isPerspectiveFeature(feature: Feature): feature is PerspectiveFeature {
-  return isPointFeature(feature) && feature.properties.type === 'perspective';
-}
-
-function isCompteurFeature(feature: Feature): feature is CompteurFeature {
-  return isPointFeature(feature) && ['compteur-velo', 'compteur-voiture'].includes(feature.properties.type);
 }
 
 export const useMap = () => {
@@ -575,7 +494,7 @@ export const useMap = () => {
       return;
     }
     compteurs
-      .sort((c1, c2) => c2.properties.counts?.at(-1).count - c1.properties.counts?.at(-1).count)
+      .sort((c1, c2) => (c2.properties.counts.at(-1)?.count ?? 0) - (c1.properties.counts.at(-1)?.count ?? 0))
       .map((c, i) => {
         // top counters are bigger and drawn above others
         const top = 10;

--- a/composables/useStats.ts
+++ b/composables/useStats.ts
@@ -1,29 +1,11 @@
-type Feature = {
-  type: string;
-  properties: {
-    id?: string;
-    line: number;
-    name: string;
-    status: 'done' | 'wip' | 'planned' | 'postponed' | 'unknown' | 'variante' | 'variante-postponed';
-    doneAt?: string;
-  };
-  geometry: {
-    type: string;
-    coordinates: number[][];
-  };
-};
-
-type Geojson = {
-  type: string;
-  features: Feature[];
-};
+import { type Geojson, type Feature, isLineStringFeature } from '../types';
 
 export const useStats = () => {
   function getAllUniqLineStrings(voies: Geojson[]) {
     return voies
       .map(voie => voie.features)
       .flat()
-      .filter(feature => feature.geometry.type === 'LineString')
+      .filter(isLineStringFeature)
       .filter((feature, index, sections) => {
         if (feature.properties.id === undefined) {
           return true;
@@ -84,7 +66,7 @@ export const useStats = () => {
     return Math.round(radius * c);
   }
 
-  function displayDistanceInKm(distance: number, precision: number) {
+  function displayDistanceInKm(distance: number, precision = 0) {
     if (distance === 0) {
       return '0 km';
     }

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,0 +1,94 @@
+export type LineStringFeature = {
+  type: 'Feature';
+  properties: {
+    id?: string
+    line: number;
+    name: string;
+    status: 'done' | 'wip' | 'planned' | 'postponed' | 'unknown' | 'variante' | 'variante-postponed';
+    type?: string;
+    doneAt?: string;
+    link?: string;
+  };
+  geometry: {
+    type: 'LineString';
+    coordinates: [number, number][];
+  };
+};
+
+export type ColoredLineStringFeature = LineStringFeature & { properties: { color: string } };
+
+export type PerspectiveFeature = {
+  type: 'Feature';
+  properties: {
+    type: 'perspective';
+    line: number;
+    name: string;
+    imgUrl: string;
+  };
+  geometry: {
+    type: 'Point';
+    coordinates: [number, number];
+  };
+};
+
+export type CompteurFeature = {
+  type: 'Feature';
+  properties: {
+    type: 'compteur-velo' | 'compteur-voiture',
+    line: number;
+    name: string;
+    link?: string;
+    counts: Array<{
+      month: string;
+      count: number;
+    }>;
+    /**
+     * z-index like
+     */
+    circleSortKey?: number;
+    circleRadius?: number;
+    circleStrokeWidth?: number;
+  };
+  geometry: {
+    type: 'Point';
+    coordinates: [number, number];
+  };
+};
+
+type PointFeature = PerspectiveFeature | CompteurFeature;
+
+export type Feature = LineStringFeature | PointFeature;
+
+export type Compteur = {
+  name: string;
+  _path: string;
+  description: string;
+  idPdc: number;
+  coordinates: [number, number];
+  lines: number[];
+  counts: Array<{
+    month: string;
+    count: number;
+  }>;
+};
+
+export type Geojson = {
+  type: string;
+  features: Feature[];
+};
+
+export function isLineStringFeature(feature: Feature): feature is LineStringFeature {
+  return feature.geometry.type === 'LineString';
+}
+
+export function isPointFeature(feature: Feature): feature is PointFeature {
+  return feature.geometry.type === 'Point';
+}
+
+export function isPerspectiveFeature(feature: Feature): feature is PerspectiveFeature {
+  return isPointFeature(feature) && feature.properties.type === 'perspective';
+}
+
+export function isCompteurFeature(feature: Feature): feature is CompteurFeature {
+  return isPointFeature(feature) && ['compteur-velo', 'compteur-voiture'].includes(feature.properties.type);
+}


### PR DESCRIPTION
Bonjour

Cette PR est purement technique.

De nombreux components et composables re-décrivaient avec plus ou moins de fidélité des props de type `Feature`, `Perspective`…

Cela conduisait à des situations où la source de vérité était contradictoire.

Par exemple `useStats` savait que le statut des lignes est `'done' | 'wip' | 'planned' | 'postponed' | 'unknown' | 'variante' | 'variante-postponed'`, `LineToolTip` n'était au courant que d'un sous-ensemble, alors que `useMap` n'en savait rien du tout.

Le travail de typage était déja relativement complet coté `useStats`, il suffisait juste de le redistribuer plus largement dans la codebase pour que l'IDE puisse bénéficier de plus de type-safety.
Ce n'est pas encore parfait partout, mais c'est déjà une bonne partie (le ratio lignes ajoutées / lignes retirées est encourageant) et le reste de correctifs pourra être fait au fil de l'eau dans des PR futures.
(si jamais cela introduit un conflit de merge éventuel avec les autres PRs en cours, je m'en chargerai)