### PR TITLE
feat(legend): add typology toggles

### DIFF
--- a/components/LegendModal.vue
+++ b/components/LegendModal.vue
@@ -16,7 +16,9 @@
         <DialogTitle class="text-lg font-medium leading-6 text-gray-900">
           Légende
         </DialogTitle>
+
         <div class="mt-2">
+          <h3>Statuts</h3>
           <div class="grid grid-cols-[64px_1fr] gap-x-4">
             <div class="my-auto rounded-md border-gray-500 border">
               <div class="h-1 relative">
@@ -27,7 +29,7 @@
             </div>
             <div>
               <label>
-                <input v-model="legendItems.planned.isEnable" type="checkbox">
+                <input v-model="legendStatuses.planned.isEnable" type="checkbox">
                 prévu pour 2026
               </label>
             </div>
@@ -37,7 +39,7 @@
             </div>
             <div>
               <label>
-                <input v-model="legendItems.done.isEnable" type="checkbox">
+                <input v-model="legendStatuses.done.isEnable" type="checkbox">
                 terminé
               </label>
             </div>
@@ -51,7 +53,7 @@
             </div>
             <div>
               <label>
-                <input v-model="legendItems.wip.isEnable" type="checkbox">
+                <input v-model="legendStatuses.wip.isEnable" type="checkbox">
                 en travaux
               </label>
             </div>
@@ -63,7 +65,7 @@
             </div>
             <div>
               <label>
-                <input v-model="legendItems.unknown.isEnable" type="checkbox">
+                <input v-model="legendStatuses.unknown.isEnable" type="checkbox">
                 linéaire inconnu
               </label>
             </div>
@@ -76,8 +78,93 @@
             </div>
             <div>
               <label>
-                <input v-model="legendItems.postponed.isEnable" type="checkbox">
+                <input v-model="legendStatuses.postponed.isEnable" type="checkbox">
                 reporté après 2026
+              </label>
+            </div>
+          </div>
+        </div>
+
+        <div class="mt-2">
+          <h3>Typologie</h3>
+          <div class="grid grid-cols-[64px_1fr] gap-x-4">
+            <div />
+            <div>
+              <label>
+                <input v-model="legendTypes.bidirectionnelle.isEnable" type="checkbox">
+                Piste cyclable bidirectionnelle
+              </label>
+            </div>
+
+            <div />
+            <div>
+              <label>
+                <input v-model="legendTypes.bilaterale.isEnable" type="checkbox">
+                Piste cyclable bilatérale
+              </label>
+            </div>
+
+            <div />
+            <div>
+              <label>
+                <input v-model="legendTypes['voie-bus'].isEnable" type="checkbox">
+                Voie bus
+              </label>
+            </div>
+
+            <div />
+            <div>
+              <label>
+                <input v-model="legendTypes['voie-bus-elargie'].isEnable" type="checkbox">
+                Voie bus élargie
+              </label>
+            </div>
+
+            <div />
+            <div>
+              <label>
+                <input v-model="legendTypes.velorue.isEnable" type="checkbox">
+                Vélorue
+              </label>
+            </div>
+
+            <div />
+            <div>
+              <label>
+                <input v-model="legendTypes['voie-verte'].isEnable" type="checkbox">
+                Voie verte
+              </label>
+            </div>
+
+            <div />
+            <div>
+              <label>
+                <input v-model="legendTypes['bandes-cyclables'].isEnable" type="checkbox">
+                Bandes cyclables
+              </label>
+            </div>
+
+            <div />
+            <div>
+              <label>
+                <input v-model="legendTypes['zone-de-rencontre'].isEnable" type="checkbox">
+                Zone de rencontre
+              </label>
+            </div>
+
+            <div />
+            <div>
+              <label>
+                <input v-model="legendTypes.aucun.isEnable" type="checkbox">
+                Aucun
+              </label>
+            </div>
+
+            <div />
+            <div>
+              <label>
+                <input v-model="legendTypes.inconnu.isEnable" type="checkbox">
+                Inconnu
               </label>
             </div>
           </div>
@@ -103,7 +190,7 @@ defineExpose({
   openModal
 });
 
-const legendItems = ref({
+const legendStatuses = ref({
   planned: {
     isEnable: true,
     statuses: ['planned', 'variante']
@@ -126,14 +213,65 @@ const legendItems = ref({
   }
 });
 
-const emit = defineEmits(['update:visibleStatuses']);
+const legendTypes = ref({
+  bidirectionnelle: {
+    isEnable: true,
+    types: ['bidirectionnelle']
+  },
+  bilaterale: {
+    isEnable: true,
+    types: ['bilaterale']
+  },
+  'voie-bus': {
+    isEnable: true,
+    types: ['voie-bus']
+  },
+  'voie-bus-elargie': {
+    isEnable: true,
+    types: ['voie-bus-elargie']
+  },
+  velorue: {
+    isEnable: true,
+    types: ['velorue']
+  },
+  'voie-verte': {
+    isEnable: true,
+    types: ['voie-verte']
+  },
+  'bandes-cyclables': {
+    isEnable: true,
+    types: ['bandes-cyclables']
+  },
+  'zone-de-rencontre': {
+    isEnable: true,
+    types: ['zone-de-rencontre']
+  },
+  aucun: {
+    isEnable: true,
+    types: ['aucun']
+  },
+  inconnu: {
+    isEnable: true,
+    types: ['inconnu']
+  }
+});
 
-watch(legendItems, () => {
-  const visibleStatuses = Object.values(legendItems.value)
+const emit = defineEmits(['update:visibleStatuses', 'update:visibleTypes']);
+
+watch(legendStatuses, () => {
+  const visibleStatuses = Object.values(legendStatuses.value)
     .filter(item => item.isEnable)
     .flatMap(item => item.statuses);
 
   emit('update:visibleStatuses', visibleStatuses);
+}, { deep: true });
+
+watch(legendTypes, () => {
+  const visibleTypes = Object.values(legendTypes.value)
+    .filter(item => item.isEnable)
+    .flatMap(item => item.types);
+
+  emit('update:visibleTypes', visibleTypes);
 }, { deep: true });
 
 </script>

--- a/components/Map.vue
+++ b/components/Map.vue
@@ -1,6 +1,10 @@
 <template>
   <div class="relative">
-    <LegendModal ref="legendModalComponent" @update:visible-statuses="refreshVisibleStatuses" />
+    <LegendModal
+      ref="legendModalComponent"
+      @update:visible-statuses="refreshVisibleStatuses"
+      @update:visible-types="refreshVisibleTypes"
+    />
     <div id="map" class="rounded-lg h-full w-full" />
     <img
       v-if="options.logo"
@@ -57,14 +61,31 @@ const {
 } = useMap();
 
 const visibleStatuses = ref(['planned', 'variante', 'done', 'postponed', 'variante-postponed', 'unknown', 'wip']);
+const visibleTypes = ref([
+  'bidirectionnelle',
+  'bilaterale',
+  'voie-bus',
+  'voie-bus-elargie',
+  'velorue',
+  'voie-verte',
+  'bandes-cyclables',
+  'zone-de-rencontre',
+  'aucun',
+  'inconnu'
+]);
+
 const features = computed(() => {
   return (props.features ?? []).filter(feature => {
-    return visibleStatuses.value.includes(feature.properties.status);
+    return visibleStatuses.value.includes(feature.properties.status) && visibleTypes.value.includes(feature.properties.type);
   });
 });
 
 function refreshVisibleStatuses(newVisibleStatuses) {
   visibleStatuses.value = newVisibleStatuses;
+}
+
+function refreshVisibleTypes(newVisibleTypes) {
+  visibleTypes.value = newVisibleTypes;
 }
 
 onMounted(() => {


### PR DESCRIPTION
Bonjour

Cette PR poursuit le travail de ces dernières semaines quant à la typologie des VLs en les faisant apparaître dans la légende de la carte.

![image](https://github.com/benoitdemaegdt/voieslyonnaises/assets/39315/d8820cb0-5574-468f-83b2-616cbbc907a2)

Le design est en l'état un peu spartiate mais cette fonctionnalité apporte malgré tout de la valeur pour le croisement des 2 niveaux de lecture des données (status vs types) en attendant de repenser ce panneau légende plus en profondeur (layers, compteurs…).