### PR TITLE
feat(carto): ajout d'un bouton pour gérer les filtres

### DIFF
--- a/components/FilterModal.vue
+++ b/components/FilterModal.vue
@@ -1,0 +1,92 @@
+<template>
+  <Dialog :open="isOpen" class="relative z-50" @close="closeModal">
+    <!-- backdrop-->
+    <div class="fixed inset-0 bg-black/30" aria-hidden="true" />
+
+    <!-- dialog itself-->
+    <div class="fixed inset-0 flex items-center justify-center p-4">
+      <DialogPanel class="relative p-4 w-full max-w-sm rounded bg-white">
+        <button
+          type="button"
+          class="absolute top-1 right-1 bg-white rounded-md p-1 inline-flex items-center justify-center text-gray-400 hover:text-gray-500 hover:bg-gray-100"
+          @click="closeModal"
+        >
+          <Icon name="mdi:close" class="h-6 w-6" aria-hidden="true" />
+        </button>
+        <DialogTitle class="text-lg font-medium leading-6 text-gray-900">
+          Filtres
+        </DialogTitle>
+        <div class="mt-2">
+          <div class="text-base">
+            Filtrer par statut d'avancement
+          </div>
+          <div v-for="statusFilter in statusFilters" :key="statusFilter.label">
+            <label>
+              <input v-model="statusFilter.isEnable" type="checkbox">
+              {{ statusFilter.label }}
+            </label>
+          </div>
+          <div class="text-base">
+            Filtrer par type d'aménagement
+          </div>
+          <div v-for="typeFilter in typeFilters" :key="typeFilter.label">
+            <label>
+              <input v-model="typeFilter.isEnable" type="checkbox">
+              {{ typeFilter.label }}
+            </label>
+          </div>
+        </div>
+      </DialogPanel>
+    </div>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import { Dialog, DialogPanel, DialogTitle } from '@headlessui/vue';
+
+const isOpen = ref(false);
+
+function closeModal() {
+  isOpen.value = false;
+}
+function openModal() {
+  isOpen.value = true;
+}
+
+defineExpose({
+  openModal
+});
+
+const statusFilters = ref([
+  { label: 'Prévu pour 2026', isEnable: true, statuses: ['planned', 'variante'] },
+  { label: 'Terminé', isEnable: true, statuses: ['done'] },
+  { label: 'Reporté', isEnable: true, statuses: ['postponed', 'variante-postponed'] },
+  { label: 'Inconnu', isEnable: true, statuses: ['unknown'] },
+  { label: 'En travaux', isEnable: true, statuses: ['wip'] }
+]);
+
+const typeFilters = ref([
+  { label: 'Bidirectionnelle', isEnable: true, types: ['bidirectionnelle'] },
+  { label: 'Bilaterale', isEnable: true, types: ['bilaterale'] },
+  { label: 'Voie Bus', isEnable: true, types: ['voie-bus', 'voie-bus-elargie'] },
+  { label: 'Voie verte', isEnable: true, types: ['voie-verte'] },
+  { label: 'Vélorue', isEnable: true, types: ['velorue'] },
+  { label: 'Bandes cyclables', isEnable: true, types: ['bandes-cyclables'] },
+  { label: 'Zone de rencontre', isEnable: true, types: ['zone-de-rencontre'] }
+]);
+
+const emit = defineEmits(['update']);
+
+watch([statusFilters, typeFilters], () => {
+  const visibleStatuses = statusFilters.value
+    .filter(item => item.isEnable)
+    .flatMap(item => item.statuses);
+
+  const visibleTypes = typeFilters.value
+    .filter(item => item.isEnable)
+    .flatMap(item => item.types);
+
+  emit('update', { visibleStatuses, visibleTypes });
+}, { deep: true });
+
+</script>

--- a/components/FilterModal.vue
+++ b/components/FilterModal.vue
@@ -20,20 +20,36 @@
           <div class="text-base">
             Filtrer par statut d'avancement
           </div>
-          <div v-for="statusFilter in statusFilters" :key="statusFilter.label">
-            <label>
-              <input v-model="statusFilter.isEnable" type="checkbox">
+          <div class="mt-2 flex flex-wrap gap-x-2 gap-y-3">
+            <div
+              v-for="(statusFilter, index) in statusFilters"
+              :key="statusFilter.label"
+              class="px-2 py-1 border rounded-2xl text-sm cursor-pointer focus:outline-none ring-lvv-blue-600 ring-2"
+              :class="{
+                'bg-lvv-blue-600 border-transparent text-white ring-offset-1 hover:bg-lvv-blue-500': statusFilter.isEnable,
+                'bg-white border-gray-200 text-gray-900 hover:bg-gray-50': !statusFilter.isEnable
+              }"
+              @click="toogleStatusFilter(index)"
+            >
               {{ statusFilter.label }}
-            </label>
+            </div>
           </div>
-          <div class="text-base">
+          <div class="mt-2 text-base">
             Filtrer par type d'aménagement
           </div>
-          <div v-for="typeFilter in typeFilters" :key="typeFilter.label">
-            <label>
-              <input v-model="typeFilter.isEnable" type="checkbox">
+          <div class="mt-2 flex flex-wrap gap-x-2 gap-y-3">
+            <div
+              v-for="(typeFilter, index) in typeFilters"
+              :key="typeFilter.label"
+              class="px-2 py-1 border rounded-2xl text-sm cursor-pointer focus:outline-none ring-lvv-blue-600 ring-2"
+              :class="{
+                'bg-lvv-blue-600 border-transparent text-white ring-offset-1 hover:bg-lvv-blue-500': typeFilter.isEnable,
+                'bg-white border-gray-200 text-gray-900 hover:bg-gray-50': !typeFilter.isEnable
+              }"
+              @click="toogleTypeFilter(index)"
+            >
               {{ typeFilter.label }}
-            </label>
+            </div>
           </div>
         </div>
       </DialogPanel>
@@ -58,11 +74,11 @@ defineExpose({
 });
 
 const statusFilters = ref([
-  { label: 'Prévu pour 2026', isEnable: true, statuses: ['planned', 'variante'] },
   { label: 'Terminé', isEnable: true, statuses: ['done'] },
+  { label: 'En travaux', isEnable: true, statuses: ['wip'] },
+  { label: 'Prévu pour 2026', isEnable: true, statuses: ['planned', 'variante'] },
   { label: 'Reporté', isEnable: true, statuses: ['postponed', 'variante-postponed'] },
-  { label: 'Inconnu', isEnable: true, statuses: ['unknown'] },
-  { label: 'En travaux', isEnable: true, statuses: ['wip'] }
+  { label: 'Inconnu', isEnable: true, statuses: ['unknown'] }
 ]);
 
 const typeFilters = ref([
@@ -72,8 +88,18 @@ const typeFilters = ref([
   { label: 'Voie verte', isEnable: true, types: ['voie-verte'] },
   { label: 'Vélorue', isEnable: true, types: ['velorue'] },
   { label: 'Bandes cyclables', isEnable: true, types: ['bandes-cyclables'] },
-  { label: 'Zone de rencontre', isEnable: true, types: ['zone-de-rencontre'] }
+  { label: 'Zone de rencontre', isEnable: true, types: ['zone-de-rencontre'] },
+  { label: 'Inconnu', isEnable: true, types: ['inconnu'] },
+  { label: 'Aucun', isEnable: true, types: ['aucun'] }
 ]);
+
+function toogleStatusFilter(index: number) {
+  statusFilters.value[index].isEnable = !statusFilters.value[index].isEnable;
+}
+
+function toogleTypeFilter(index: number) {
+  typeFilters.value[index].isEnable = !typeFilters.value[index].isEnable;
+}
 
 const emit = defineEmits(['update']);
 

--- a/components/FilterModal.vue
+++ b/components/FilterModal.vue
@@ -16,40 +16,39 @@
         <DialogTitle class="text-lg font-medium leading-6 text-gray-900">
           Filtres
         </DialogTitle>
-        <div class="mt-2">
-          <div class="text-base">
-            Filtrer par statut d'avancement
+
+        <div class="mt-2 text-base font-medium">
+          Filtrer par statut d'avancement
+        </div>
+        <div class="mt-2 flex flex-wrap gap-x-2 gap-y-3">
+          <div
+            v-for="(statusFilter, index) in statusFilters"
+            :key="statusFilter.label"
+            class="px-2 py-1 border rounded-2xl text-sm cursor-pointer focus:outline-none ring-lvv-blue-600 ring-2"
+            :class="{
+              'bg-lvv-blue-600 border-transparent text-white ring-offset-1 hover:bg-lvv-blue-500': statusFilter.isEnable,
+              'bg-white border-gray-200 text-gray-900 hover:bg-gray-50': !statusFilter.isEnable
+            }"
+            @click="toogleStatusFilter(index)"
+          >
+            {{ statusFilter.label }}
           </div>
-          <div class="mt-2 flex flex-wrap gap-x-2 gap-y-3">
-            <div
-              v-for="(statusFilter, index) in statusFilters"
-              :key="statusFilter.label"
-              class="px-2 py-1 border rounded-2xl text-sm cursor-pointer focus:outline-none ring-lvv-blue-600 ring-2"
-              :class="{
-                'bg-lvv-blue-600 border-transparent text-white ring-offset-1 hover:bg-lvv-blue-500': statusFilter.isEnable,
-                'bg-white border-gray-200 text-gray-900 hover:bg-gray-50': !statusFilter.isEnable
-              }"
-              @click="toogleStatusFilter(index)"
-            >
-              {{ statusFilter.label }}
-            </div>
-          </div>
-          <div class="mt-2 text-base">
-            Filtrer par type d'aménagement
-          </div>
-          <div class="mt-2 flex flex-wrap gap-x-2 gap-y-3">
-            <div
-              v-for="(typeFilter, index) in typeFilters"
-              :key="typeFilter.label"
-              class="px-2 py-1 border rounded-2xl text-sm cursor-pointer focus:outline-none ring-lvv-blue-600 ring-2"
-              :class="{
-                'bg-lvv-blue-600 border-transparent text-white ring-offset-1 hover:bg-lvv-blue-500': typeFilter.isEnable,
-                'bg-white border-gray-200 text-gray-900 hover:bg-gray-50': !typeFilter.isEnable
-              }"
-              @click="toogleTypeFilter(index)"
-            >
-              {{ typeFilter.label }}
-            </div>
+        </div>
+        <div class="mt-2 text-base font-medium">
+          Filtrer par type d'aménagement
+        </div>
+        <div class="mt-2 flex flex-wrap gap-x-2 gap-y-3">
+          <div
+            v-for="(typeFilter, index) in typeFilters"
+            :key="typeFilter.label"
+            class="px-2 py-1 border rounded-2xl text-sm cursor-pointer focus:outline-none ring-lvv-blue-600 ring-2"
+            :class="{
+              'bg-lvv-blue-600 border-transparent text-white ring-offset-1 hover:bg-lvv-blue-500': typeFilter.isEnable,
+              'bg-white border-gray-200 text-gray-900 hover:bg-gray-50': !typeFilter.isEnable
+            }"
+            @click="toogleTypeFilter(index)"
+          >
+            {{ typeFilter.label }}
           </div>
         </div>
       </DialogPanel>

--- a/components/LegendModal.vue
+++ b/components/LegendModal.vue
@@ -26,20 +26,14 @@
               </div>
             </div>
             <div>
-              <label>
-                <input v-model="legendItems.planned.isEnable" type="checkbox">
-                prévu pour 2026
-              </label>
+              prévu pour 2026
             </div>
 
             <div class="my-auto rounded-md border-gray-500 border">
               <div class="h-1 bg-lvv-blue-600" />
             </div>
             <div>
-              <label>
-                <input v-model="legendItems.done.isEnable" type="checkbox">
-                terminé
-              </label>
+              terminé
             </div>
 
             <div class="my-auto rounded-md border-gray-500 border">
@@ -50,10 +44,7 @@
               </div>
             </div>
             <div>
-              <label>
-                <input v-model="legendItems.wip.isEnable" type="checkbox">
-                en travaux
-              </label>
+              en travaux
             </div>
 
             <div class="my-auto h-4 rounded-md bg-lvv-blue-600 opacity-20 px-1">
@@ -62,10 +53,7 @@
               </div>
             </div>
             <div>
-              <label>
-                <input v-model="legendItems.unknown.isEnable" type="checkbox">
-                linéaire inconnu
-              </label>
+              linéaire inconnu
             </div>
 
             <div class="my-auto rounded-md border-gray-500 border relative">
@@ -75,10 +63,7 @@
               </div>
             </div>
             <div>
-              <label>
-                <input v-model="legendItems.postponed.isEnable" type="checkbox">
-                reporté après 2026
-              </label>
+              reporté après 2026
             </div>
           </div>
         </div>
@@ -102,40 +87,6 @@ function openModal() {
 defineExpose({
   openModal
 });
-
-const legendItems = ref({
-  planned: {
-    isEnable: true,
-    statuses: ['planned', 'variante']
-  },
-  done: {
-    isEnable: true,
-    statuses: ['done']
-  },
-  postponed: {
-    isEnable: true,
-    statuses: ['postponed', 'variante-postponed']
-  },
-  unknown: {
-    isEnable: true,
-    statuses: ['unknown']
-  },
-  wip: {
-    isEnable: true,
-    statuses: ['wip']
-  }
-});
-
-const emit = defineEmits(['update:visibleStatuses']);
-
-watch(legendItems, () => {
-  const visibleStatuses = Object.values(legendItems.value)
-    .filter(item => item.isEnable)
-    .flatMap(item => item.statuses);
-
-  emit('update:visibleStatuses', visibleStatuses);
-}, { deep: true });
-
 </script>
 
 <style>

--- a/components/Map.vue
+++ b/components/Map.vue
@@ -258,12 +258,11 @@ onMounted(() => {
   background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='29' height='29' fill='%23333'%3E%3Cpath d='M24 16v5.5c0 1.75-.75 2.5-2.5 2.5H16v-1l3-1.5-4-5.5 1-1 5.5 4 1.5-3h1zM6 16l1.5 3 5.5-4 1 1-4 5.5 3 1.5v1H7.5C5.75 24 5 23.25 5 21.5V16h1zm7-11v1l-3 1.5 4 5.5-1 1-5.5-4L6 13H5V7.5C5 5.75 5.75 5 7.5 5H13zm11 2.5c0-1.75-.75-2.5-2.5-2.5H16v1l3 1.5-4 5.5 1 1 5.5-4 1.5 3h1V7.5z'/%3E%3C/svg%3E");
 }
 
-/* TODO */
 .maplibregl-filter {
   background-repeat: no-repeat;
   background-position: center;
   pointer-events: auto;
-  background-image: url('~/maplibre/info.svg');
+  background-image: url('~/maplibre/filter.svg');
   background-size: 85%;
 }
 

--- a/components/Map.vue
+++ b/components/Map.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="relative">
-    <LegendModal ref="legendModalComponent" @update:visible-statuses="refreshVisibleStatuses" />
+    <LegendModal ref="legendModalComponent" />
+    <FilterModal ref="filterModalComponent" @update="refreshFilters" />
     <div id="map" class="rounded-lg h-full w-full" />
     <img
       v-if="options.logo"
@@ -19,12 +20,13 @@ import { Map, AttributionControl, GeolocateControl, NavigationControl, Popup, ty
 import 'maplibre-gl/dist/maplibre-gl.css';
 import style from '@/assets/style.json';
 import LegendControl from '@/maplibre/LegendControl';
+import FilterControl from '@/maplibre/FilterControl';
 import FullscreenControl from '@/maplibre/FullscreenControl';
 import ShrinkControl from '@/maplibre/ShrinkControl';
 import LineTooltip from '~/components/tooltips/LineTooltip.vue';
 import CounterTooltip from '~/components/tooltips/CounterTooltip.vue';
 import PerspectiveTooltip from '~/components/tooltips/PerspectiveTooltip.vue';
-import { isLineStringFeature, type Feature, type LaneStatus } from '~/types';
+import { isLineStringFeature, type Feature, type LaneStatus, type LaneType } from '~/types';
 
 // const config = useRuntimeConfig();
 // const maptilerKey = config.public.maptilerKey;
@@ -32,6 +34,7 @@ import { isLineStringFeature, type Feature, type LaneStatus } from '~/types';
 const defaultOptions = {
   logo: true,
   legend: true,
+  filter: true,
   geolocation: false,
   fullscreen: false,
   onFullscreenControlClick: () => { },
@@ -47,24 +50,28 @@ const props = defineProps<{
 const options = { ...defaultOptions, ...props.options };
 
 const legendModalComponent = ref(null);
+const filterModalComponent = ref(null);
 
 const {
   plotFeatures,
   fitBounds
 } = useMap();
 
-const visibleStatuses = ref(['planned', 'variante', 'done', 'postponed', 'variante-postponed', 'unknown', 'wip']);
+const statuses = ref(['planned', 'variante', 'done', 'postponed', 'variante-postponed', 'unknown', 'wip']);
+const types = ref(['bidirectionnelle', 'bilaterale', 'voie-bus', 'voie-bus-elargie', 'velorue', 'voie-verte', 'bandes-cyclables', 'zone-de-rencontre', 'aucun', 'inconnu']);
 const features = computed(() => {
   return (props.features ?? []).filter(feature => {
     if (isLineStringFeature(feature)) {
-      return visibleStatuses.value.includes(feature.properties.status);
+      return statuses.value.includes(feature.properties.status) &&
+        types.value.includes(feature.properties.type);
     }
     return true;
   });
 });
 
-function refreshVisibleStatuses(newVisibleStatuses: LaneStatus[]) {
-  visibleStatuses.value = newVisibleStatuses;
+function refreshFilters({ visibleStatuses, visibleTypes }: { visibleStatuses: LaneStatus[]; visibleTypes: LaneType[] }) {
+  statuses.value = visibleStatuses;
+  types.value = visibleTypes;
 }
 
 onMounted(() => {
@@ -109,6 +116,16 @@ onMounted(() => {
       }
     });
     map.addControl(legendControl, 'top-right');
+  }
+  if (options.filter) {
+    const filterControl = new FilterControl({
+      onClick: () => {
+        if (filterModalComponent.value) {
+          (filterModalComponent.value as any).openModal();
+        }
+      }
+    });
+    map.addControl(filterControl, 'top-right');
   }
 
   map.on('load', () => {
@@ -239,6 +256,15 @@ onMounted(() => {
   background-position: center;
   pointer-events: auto;
   background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='29' height='29' fill='%23333'%3E%3Cpath d='M24 16v5.5c0 1.75-.75 2.5-2.5 2.5H16v-1l3-1.5-4-5.5 1-1 5.5 4 1.5-3h1zM6 16l1.5 3 5.5-4 1 1-4 5.5 3 1.5v1H7.5C5.75 24 5 23.25 5 21.5V16h1zm7-11v1l-3 1.5 4 5.5-1 1-5.5-4L6 13H5V7.5C5 5.75 5.75 5 7.5 5H13zm11 2.5c0-1.75-.75-2.5-2.5-2.5H16v1l3 1.5-4 5.5 1 1 5.5-4 1.5 3h1V7.5z'/%3E%3C/svg%3E");
+}
+
+/* TODO */
+.maplibregl-filter {
+  background-repeat: no-repeat;
+  background-position: center;
+  pointer-events: auto;
+  background-image: url('~/maplibre/info.svg');
+  background-size: 85%;
 }
 
 .maplibregl-shrink {

--- a/maplibre/FilterControl.ts
+++ b/maplibre/FilterControl.ts
@@ -9,7 +9,7 @@ export default class FilterControl {
 
   onAdd() {
     this._btn = document.createElement('button');
-    this._btn.className = 'maplibregl-fullscreen maplibregl-ctrl-icon';
+    this._btn.className = 'maplibregl-filter maplibregl-ctrl-icon';
     this._btn.type = 'button';
     this._btn.title = 'Filtres';
     this._btn.onclick = () => this._onClick();

--- a/maplibre/FilterControl.ts
+++ b/maplibre/FilterControl.ts
@@ -1,0 +1,29 @@
+export default class FilterControl {
+  _btn: HTMLButtonElement;
+  _container: HTMLDivElement;
+  _onClick: Function;
+
+  constructor({ onClick }: { onClick: Function }) {
+    this._onClick = onClick;
+  }
+
+  onAdd() {
+    this._btn = document.createElement('button');
+    this._btn.className = 'maplibregl-fullscreen maplibregl-ctrl-icon';
+    this._btn.type = 'button';
+    this._btn.title = 'Filtres';
+    this._btn.onclick = () => this._onClick();
+
+    this._container = document.createElement('div');
+    this._container.className = 'maplibregl-ctrl-group maplibregl-ctrl';
+    this._container.appendChild(this._btn);
+
+    return this._container;
+  }
+
+  onRemove() {
+    if (this._container && this._container.parentNode) {
+      this._container.parentNode.removeChild(this._container);
+    }
+  }
+}

--- a/maplibre/filter.svg
+++ b/maplibre/filter.svg
@@ -1,0 +1,1 @@
+<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4h16v2.172a2 2 0 0 1-.586 1.414L15 12v7l-6 2v-8.5L4.52 7.572A2 2 0 0 1 4 6.227z"/></svg>

--- a/pages/compteurs/velo/[slug].vue
+++ b/pages/compteurs/velo/[slug].vue
@@ -7,7 +7,7 @@
     :image-url="counter.imageUrl"
   >
     <ClientOnly>
-      <Map :features="features" :options="{ legend: false }" class="mt-12" style="height: 40vh" />
+      <Map :features="features" :options="{ legend: false, filter: false }" class="mt-12" style="height: 40vh" />
     </ClientOnly>
     <h2>Total des passages par année</h2>
     <p>Ce premier diagramme représente le nombre total de passages détecté par le compteur vélo chaque année.</p>

--- a/pages/compteurs/velo/index.vue
+++ b/pages/compteurs/velo/index.vue
@@ -12,7 +12,7 @@
           Chaque début de mois, nous remontons les données de {{ counters.length }} compteurs à vélo de l'agglomération lyonnaise.
         </p>
         <ClientOnly>
-          <Map :features="features" :options="{ legend: false }" class="mt-12" style="height: 40vh" />
+          <Map :features="features" :options="{ legend: false, filter: false }" class="mt-12" style="height: 40vh" />
         </ClientOnly>
       </div>
 

--- a/pages/compteurs/voiture/[slug].vue
+++ b/pages/compteurs/voiture/[slug].vue
@@ -7,7 +7,7 @@
     :image-url="counter.imageUrl"
   >
     <ClientOnly>
-      <Map :features="features" :options="{ legend: false }" class="mt-12" style="height: 40vh" />
+      <Map :features="features" :options="{ legend: false, filter: false }" class="mt-12" style="height: 40vh" />
     </ClientOnly>
     <h2>Total des passages par année</h2>
     <p>Ce premier diagramme représente le nombre total de passages détecté par le compteur voiture chaque année.</p>

--- a/pages/compteurs/voiture/index.vue
+++ b/pages/compteurs/voiture/index.vue
@@ -9,7 +9,7 @@
           Suivi des compteurs voiture de l'agglomération lyonnaise
         </h2>
         <ClientOnly>
-          <Map :features="features" :options="{ legend: false }" class="mt-12" style="height: 40vh" />
+          <Map :features="features" :options="{ legend: false , filter: false}" class="mt-12" style="height: 40vh" />
         </ClientOnly>
       </div>
 


### PR DESCRIPTION
### Description
Je souhaite sortir les filtres de la légende, car il s'agit de 2 choses différentes.

Concrètement, ça prendrait la forme d'un bouton directement intégré dans la carte.

### TODO
- [x] Ajout de l'icône SVG
- [x] Ne pas afficher ce bouton sur la carte des compteurs
- [x] Passe de design à faire, très brut pour le moment

### Screenshots
Il faut changer l'icone, par un icone de filtre, mais ça ressemblerait à ça
<img width="955" alt="image" src="https://github.com/benoitdemaegdt/voieslyonnaises/assets/25749578/d5a83d27-bc89-416a-9245-daa2e2c885f5">
