### PR TITLE
feat(counter): display best month ever on counter page

### DIFF
--- a/pages/compteurs/velo/[slug].vue
+++ b/pages/compteurs/velo/[slug].vue
@@ -15,6 +15,7 @@
 
     <h2>Comparaison des passages pour un mois donné</h2>
     <p>Choisissez un mois dans le menu déroulant ci-dessous pour visualiser l'évolution de la fréquentation cyclable pour le même mois de chaque année.</p>
+    <p>Le meilleur mois jamais enregistré pour ce compteur est <strong>{{ bestMonthEver.month }} {{ bestMonthEver.year }}</strong> avec <strong>{{ bestMonthEver.value }}</strong> passages.</p>
     <ChartMonthComparison :title="graphTitles.monthComparison" :data="counter" class="mt-8 lg:p-4 lg:rounded-lg lg:shadow-md" />
 
     <template v-if="counter.limitation">
@@ -73,4 +74,14 @@ useHead({
     { hid: 'twitter:image', name: 'twitter:image', content: IMAGE_URL }
   ]
 });
+
+let bestMonthEver = counter.value.counts.reduce((best, measure) => {
+  if (!best) return measure
+  return measure.count > best.count ? measure : best
+})
+bestMonthEver = {
+  month: new Date(bestMonthEver.month).toLocaleString('fr-Fr', { month: 'long' }),
+  year: new Date(bestMonthEver.month).toLocaleString('fr-Fr', { year: 'numeric' }),
+  value: bestMonthEver.count.toLocaleString('fr-FR'),
+}
 </script>


### PR DESCRIPTION
Bonjour.

Cette PR répond à la question du meilleur mois jamais enregistré pour un compteur donné (record absolu).

Exemple avec le compteur du Quai Pierre Scize:

![image](https://github.com/user-attachments/assets/77b4f4b9-333b-4155-aa14-f186b2fa783f)
