### PR TITLE
Passage en travaux de la section Tunnel Part Dieu

### DIFF
--- a/content/voies-cyclables/ligne-2.json
+++ b/content/voies-cyclables/ligne-2.json
@@ -561,7 +561,7 @@
       "properties": {
         "line": 2,
         "name": "Part-Dieu en tunnel",
-        "status": "planned",
+        "status": "wip",
         "type": "bidirectionnelle",
         "link": "/voie-lyonnaise-2#tunnel-vivier-merle"
       },


### PR DESCRIPTION
Le tunnel Vivier Merle a été fermé pour commencer les travaux pour le passage de la VL2.  J'ai pu voir le tweet de Lyon a vélo sur la section nord du tunnel également : https://x.com/LyonAVelo/status/1842145374795862329