### PR TITLE
Nombre de voies hardcodé

### DIFF
--- a/components/home/StatSection.vue
+++ b/components/home/StatSection.vue
@@ -21,7 +21,7 @@
                   Lignes
                 </dt>
                 <dd class="order-1 text-5xl font-extrabold text-lvv-blue-600">
-                  12
+                  {{ getNbVoiesCyclables() }}
                 </dd>
               </div>
               <div class="flex flex-col border-t border-b border-gray-100 p-6 text-center sm:border-0 sm:border-l sm:border-r">
@@ -49,5 +49,5 @@
 </template>
 
 <script setup lang="ts">
-const { getRevName } = useConfig();
+const { getRevName, getNbVoiesCyclables } = useConfig();
 </script>

--- a/composables/useConfig.ts
+++ b/composables/useConfig.ts
@@ -13,5 +13,9 @@ export const useConfig = () => {
     return config.assoLink;
   }
 
-  return { getRevName, getAssoName, getAssoLink };
+  function getNbVoiesCyclables(): number {
+    return config.nbVoiesCyclables;
+  }
+
+  return { getRevName, getAssoName, getAssoLink, getNbVoiesCyclables };
 };

--- a/composables/useMap.ts
+++ b/composables/useMap.ts
@@ -10,6 +10,7 @@ import DangerTooltip from '~/components/tooltips/DangerTooltip.vue';
 import LineTooltip from '~/components/tooltips/LineTooltip.vue';
 
 type ColoredLineStringFeature = LineStringFeature & { properties: { color: string } };
+const { getNbVoiesCyclables } = useConfig();
 
 // features plotted last are on top
 const sortOrder = [1, 3, 2, 4, 5, 6, 7, 12, 8, 9, 10, 11].reverse();
@@ -411,7 +412,7 @@ export const useMap = () => {
     const sections = features.filter(feature => feature.properties.status === 'postponed');
 
     if (sections.length === 0) {
-      for (let line = 1; line <= 12; line++) {
+      for (let line = 1; line <= getNbVoiesCyclables(); line++) {
         upsertMapSource(map, `postponed-sections-${getLineColor(line)}`, []);
       }
       return;

--- a/config.json
+++ b/config.json
@@ -11,6 +11,7 @@
     45.757198
   ],
   "zoom": 12,
+  "nbVoiesCyclables": 12,
   "colors": [
     {
       "line": 1,


### PR DESCRIPTION
Rebonjour,

Petite PR pour corriger le nombre de voies.
Il est actuellement hardcodé à 2 endroits (page d'accueil + affichage des postplanned sur la carte).

Je propose de créer une variable de configuration pour la gérer (à 12 par défaut).
On pourrait aussi compter le nombre de fichiers de content/voies-cyclables/*.json mais j'ai peur que des effets de bord puissent apparaître.


### Breaking change ❌
Aucun

### Reco pour les forks 👀 
Changement à appliquer sur les forks.
