### PR TITLE
feat(content): image markdown clickable avec redirection

### DIFF
--- a/components/content/ContentImage.vue
+++ b/components/content/ContentImage.vue
@@ -1,6 +1,17 @@
 <template>
   <figure class="grid grid-cols-1 justify-items-center">
+    <NuxtLink v-if="link" :to="link" target="_blank" class="not-prose">
+      <img
+        class="w-full rounded-lg"
+        :src="imageUrl"
+        :alt="caption"
+        loading="lazy"
+        width="1310"
+        height="873"
+      >
+    </NuxtLink>
     <img
+      v-else
       class="w-full rounded-lg"
       :src="imageUrl"
       :alt="caption"
@@ -8,7 +19,7 @@
       width="1310"
       height="873"
     >
-    <figcaption class="text-center">
+    <figcaption v-if="caption" class="text-center">
       {{ caption }}
     </figcaption>
     <div v-if="credit" class="text-base text-center italic">
@@ -23,8 +34,9 @@
 <script setup>
 defineProps({
   imageUrl: { type: String, required: true },
-  caption: { type: String, required: false },
-  credit: { type: String, required: false },
-  streetView: { type: String, required: false }
+  link: { type: String, required: false, default: undefined },
+  caption: { type: String, required: false, default: undefined },
+  credit: { type: String, required: false, default: undefined },
+  streetView: { type: String, required: false, default: undefined }
 });
 </script>


### PR DESCRIPTION
### Description
Quand on ajoute une image dans un markdown : possibilité de lui passer un `link` qui permet de rediriger vers ce lien quand on clique sur l'image.

Exemple : 

```
::content-image
---
imageUrl: https://cyclopolis.lavilleavelo.org/vl1/croix-luizet.jpeg
link: https://google.fr
caption: Aperçu de la Voie Lyonnaise 1 franchissant le canal de Jonage (Villeurbanne)
credit: SYTRAL Mobilités
streetView: 45.7832245,4.8937612,3a,75y,259.87h,90t
---
::
```

<img width="1061" alt="image" src="https://github.com/user-attachments/assets/f854e540-8166-44e2-87c8-c8740a36c13c">
