### PR TITLE
feat(counters): add Passerelle de la Paix and Cours Vitton

### DIFF
--- a/content/compteurs/velo/cours-vitton-sncf.json
+++ b/content/compteurs/velo/cours-vitton-sncf.json
@@ -1,0 +1,53 @@
+{
+  "name": "Cours Vitton Pont SNCF",
+  "description": "Le compteur vélo du Cours Vitton mesure la fréquentation cycliste à hauteur du pont SNCF.",
+  "arrondissement": "Lyon 6",
+  "idPdc": 300039580,
+  "coordinates": [
+    4.858671426773072,
+    45.77007124977601
+  ],
+  "lines": [],
+  "counts": [
+    {
+      "month": "2024-02-01",
+      "count": 0
+    },
+    {
+      "month": "2024-03-01",
+      "count": 17751
+    },
+    {
+      "month": "2024-04-01",
+      "count": 113316
+    },
+    {
+      "month": "2024-05-01",
+      "count": 123572
+    },
+    {
+      "month": "2024-06-01",
+      "count": 111358
+    },
+    {
+      "month": "2024-07-01",
+      "count": 102539
+    },
+    {
+      "month": "2024-08-01",
+      "count": 86524
+    },
+    {
+      "month": "2024-09-01",
+      "count": 129978
+    },
+    {
+      "month": "2024-10-01",
+      "count": 133308
+    },
+    {
+      "month": "2024-11-01",
+      "count": 125286
+    }
+  ]
+}

--- a/content/compteurs/velo/passerelle-de-la-paix.json
+++ b/content/compteurs/velo/passerelle-de-la-paix.json
@@ -1,0 +1,55 @@
+{
+  "name": "Passerelle de la Paix",
+  "description": "Le compteur vélo de la Passerelle de la Paix mesure la fréquentation cycliste de la passerelle du même nom.",
+  "arrondissement": "Lyon 6",
+  "idPdc": 300039587,
+  "coordinates": [
+    4.854727238416673,
+    45.786159070647074
+  ],
+  "lines": [
+    2
+  ],
+  "counts": [
+    {
+      "month": "2024-02-01",
+      "count": 22361
+    },
+    {
+      "month": "2024-03-01",
+      "count": 43639
+    },
+    {
+      "month": "2024-04-01",
+      "count": 40445
+    },
+    {
+      "month": "2024-05-01",
+      "count": 43774
+    },
+    {
+      "month": "2024-06-01",
+      "count": 50130
+    },
+    {
+      "month": "2024-07-01",
+      "count": 46807
+    },
+    {
+      "month": "2024-08-01",
+      "count": 34210
+    },
+    {
+      "month": "2024-09-01",
+      "count": 48383
+    },
+    {
+      "month": "2024-10-01",
+      "count": 46382
+    },
+    {
+      "month": "2024-11-01",
+      "count": 41757
+    }
+  ]
+}


### PR DESCRIPTION
Bonjour

Cette PR ajouter deux nouveaux compteurs dans le 6ème arrondissement.
- Passerelle de la Paix
- Cours Vitton pont SNCF

![image](https://github.com/user-attachments/assets/9c053e6c-123e-43f4-8a42-ebf0a6af33e6)

Les données sont à jour, Novembre 2024 est bien inclus.

Merci à Audrey pour la notif: https://github.com/benoitdemaegdt/voieslyonnaises/issues/486