### PR TITLE
Supprime icônes X et remplace par Bsky et Masto

### DIFF
--- a/components/app/Footer.vue
+++ b/components/app/Footer.vue
@@ -60,6 +60,11 @@ const socials = [
     icon: 'mdi:instagram'
   },
   {
+    name: 'Github',
+    href: 'https://github.com/benoitdemaegdt/voieslyonnaises',
+    icon: 'mdi:github'
+  },
+  {
     name: 'Site web',
     href: 'https://lavilleavelo.org/',
     icon: 'mdi:link'

--- a/components/app/Footer.vue
+++ b/components/app/Footer.vue
@@ -35,9 +35,14 @@ const links = [
 
 const socials = [
   {
-    name: 'Twitter',
-    href: 'https://twitter.com/LaVilleaVelo',
-    icon: 'mdi:twitter'
+    name: 'Bluesky',
+    href: 'https://bsky.app/profile/lavilleavelo.bsky.social',
+    icon: 'fa6-brands:bluesky'
+  },
+  {
+    name: 'Mastodon',
+    href: 'https://masto.bike/@lavilleavelo',
+    icon: 'mdi:mastodon'
   },
   {
     name: 'Facebook',


### PR DESCRIPTION
Petite PR pour:
- supprimer l'icone et lien vers X
- ajout de Bluesky et mastodon
- ajout de github

![CleanShot 2024-12-23 at 17 22 20@2x](https://github.com/user-attachments/assets/f8bbbcfa-d4df-4320-982d-6d2968d77a7b)

