### PR TITLE
feat(counters): add 3 bike counters

### DIFF
--- a/content/compteurs/velo/avenue-georges-pompidou.json
+++ b/content/compteurs/velo/avenue-georges-pompidou.json
@@ -1,0 +1,35 @@
+{
+  "name": "Avenue Georges Pompidou Pont SNCF",
+  "description": "Le compteur vélo de l'Avenue Georges Pompidou au niveau de la Gare Part-Dieu.",
+  "arrondissement": "Lyon 3",
+  "idPdc": 300039247,
+  "coordinates": [
+    4.860876202583314,
+    45.7588856089619
+  ],
+  "lines": [
+    10
+  ],
+  "counts": [
+    {
+      "month": "2024-08-01",
+      "count": 4569
+    },
+    {
+      "month": "2024-09-01",
+      "count": 44105
+    },
+    {
+      "month": "2024-10-01",
+      "count": 57318
+    },
+    {
+      "month": "2024-11-01",
+      "count": 57651
+    },
+    {
+      "month": "2024-12-01",
+      "count": 51404
+    }
+  ]
+}

--- a/content/compteurs/velo/quai-clemenceau-castellane.json
+++ b/content/compteurs/velo/quai-clemenceau-castellane.json
@@ -1,0 +1,61 @@
+{
+  "name": "Quai Clémenceau Montée Castellane",
+  "description": "Le compteur vélo du Quai Clémenceau au pied de la montée Castellane.",
+  "arrondissement": "Caluire",
+  "idPdc": 300039240,
+  "coordinates": [
+    4.835540056228639,
+    45.79689417288023
+  ],
+  "lines": [],
+  "counts": [
+    {
+      "month": "2024-01-01",
+      "count": 0
+    },
+    {
+      "month": "2024-02-01",
+      "count": 0
+    },
+    {
+      "month": "2024-03-01",
+      "count": 0
+    },
+    {
+      "month": "2024-04-01",
+      "count": 0
+    },
+    {
+      "month": "2024-05-01",
+      "count": 0
+    },
+    {
+      "month": "2024-06-01",
+      "count": 12717
+    },
+    {
+      "month": "2024-07-01",
+      "count": 11798
+    },
+    {
+      "month": "2024-08-01",
+      "count": 8919
+    },
+    {
+      "month": "2024-09-01",
+      "count": 11772
+    },
+    {
+      "month": "2024-10-01",
+      "count": 10301
+    },
+    {
+      "month": "2024-11-01",
+      "count": 8805
+    },
+    {
+      "month": "2024-12-01",
+      "count": 6474
+    }
+  ]
+}

--- a/content/compteurs/velo/rue-louis-bouquet.json
+++ b/content/compteurs/velo/rue-louis-bouquet.json
@@ -1,0 +1,77 @@
+{
+  "name": "Rue Louis Bouquet",
+  "description": "Le compteur vélo de la rue Louis Bouquet.",
+  "arrondissement": "Lyon 9",
+  "idPdc": 300030756,
+  "coordinates": [
+    4.8192013800144196,
+    45.79309317322208
+  ],
+  "lines": [],
+  "counts": [
+    {
+      "month": "2023-09-01",
+      "count": 0
+    },
+    {
+      "month": "2023-10-01",
+      "count": 0
+    },
+    {
+      "month": "2023-11-01",
+      "count": 0
+    },
+    {
+      "month": "2023-12-01",
+      "count": 0
+    },
+    {
+      "month": "2024-01-01",
+      "count": 0
+    },
+    {
+      "month": "2024-02-01",
+      "count": 0
+    },
+    {
+      "month": "2024-03-01",
+      "count": 0
+    },
+    {
+      "month": "2024-04-01",
+      "count": 0
+    },
+    {
+      "month": "2024-05-01",
+      "count": 0
+    },
+    {
+      "month": "2024-06-01",
+      "count": 0
+    },
+    {
+      "month": "2024-07-01",
+      "count": 0
+    },
+    {
+      "month": "2024-08-01",
+      "count": 0
+    },
+    {
+      "month": "2024-09-01",
+      "count": 0
+    },
+    {
+      "month": "2024-10-01",
+      "count": 2534
+    },
+    {
+      "month": "2024-11-01",
+      "count": 3314
+    },
+    {
+      "month": "2024-12-01",
+      "count": 2359
+    }
+  ]
+}


### PR DESCRIPTION
- Avenue Georges Pompidou Pont SNCF - Lyon 3
- Quai Clémenceau Montée Castellane - Caluire
- Rue Louis Bouquet - Lyon 9

![image](https://github.com/user-attachments/assets/40bc84a9-ee2f-468f-9293-108e557012f4)
