### PR TITLE
feat: include arrondissement field in counters filter

### DIFF
--- a/helpers/helpers.ts
+++ b/helpers/helpers.ts
@@ -10,3 +10,13 @@ export function groupBy<T, K extends string>(array: T[], predicate: (value: T, i
     {} as Record<K, T[]>
   );
 }
+
+/**
+ * To ease comparison from user inputs
+ */
+export function removeDiacritics(string: string) {
+  return string
+    .normalize('NFD')
+    .replace(/[\u0300-\u036F]/g, '')
+    .toLowerCase();
+}

--- a/pages/compteurs/velo/index.vue
+++ b/pages/compteurs/velo/index.vue
@@ -37,6 +37,7 @@
 
 <script setup lang="ts">
 import type { CounterParsedContent } from '../../../types/counters';
+import { removeDiacritics } from '~/helpers/helpers';
 
 const { getCompteursFeatures } = useMap();
 
@@ -54,7 +55,7 @@ const counters = computed(() => {
       const count2 = counter2.counts.at(-1)?.count ?? 0;
       return count2 - count1;
     })
-    .filter(counter => counter.name.normalize('NFD').replace(/[\u0300-\u036F]/g, '').toLowerCase().includes(searchText.value.normalize('NFD').replace(/[\u0300-\u036F]/g, '').toLowerCase()));
+    .filter(counter => removeDiacritics(`${counter.arrondissement} ${counter.name}`).includes(removeDiacritics(searchText.value)));
 });
 
 const features = getCompteursFeatures({ counters: allCounters.value, type: 'compteur-velo' });

--- a/pages/compteurs/voiture/index.vue
+++ b/pages/compteurs/voiture/index.vue
@@ -34,6 +34,7 @@
 
 <script setup lang="ts">
 import type { CounterParsedContent } from '../../../types/counters';
+import { removeDiacritics } from '~/helpers/helpers';
 
 const { getCompteursFeatures } = useMap();
 
@@ -51,7 +52,7 @@ const counters = computed(() => {
       const count2 = counter2.counts.at(-1)?.count ?? 0;
       return count2 - count1;
     })
-    .filter(counter => counter.name.normalize('NFD').replace(/[\u0300-\u036F]/g, '').toLowerCase().includes(searchText.value.normalize('NFD').replace(/[\u0300-\u036F]/g, '').toLowerCase()));
+    .filter(counter => removeDiacritics(`${counter.arrondissement} ${counter.name}`).includes(removeDiacritics(searchText.value)));
 });
 
 const features = getCompteursFeatures({ counters: allCounters.value, type: 'compteur-voiture' });


### PR DESCRIPTION
Bonjour

Avec ce changement, l'utilisateur peut désormais filtrer les compteurs vélo et voitures par arrondissement / commune: `Lyon 4`, `Bron`…

Réference: https://github.com/benoitdemaegdt/voieslyonnaises/issues/485