### PR TITLE
Mise à jour coordonnées compteur voiture Kitchener

### DIFF
--- a/content/compteurs/voiture/pont-kitchener-marchand.json
+++ b/content/compteurs/voiture/pont-kitchener-marchand.json
@@ -12,8 +12,8 @@
   ],
   "cyclopolisId": "pont-kitchener",
   "coordinates": [
-    4.814421133922526,
-    45.77449789129417
+    4.822335,
+    45.751426
   ],
   "counts": [
     {


### PR DESCRIPTION
Les coordonnées du compteur voiture Kitchener étaient superposées avec celui du tunnel de la X Rousse.