### PR TITLE
feat: Add link to voie lyonnaise page in tooltip

### DIFF
--- a/components/tooltips/LineTooltip.vue
+++ b/components/tooltips/LineTooltip.vue
@@ -11,7 +11,9 @@
           class="h-8 w-8 rounded-full flex items-center justify-center text-white text-base font-bold"
           :style="`background-color: ${getLineColor(line)}`"
         >
-          {{ line }}
+          <a :href="`/voie-lyonnaise-${line}`">
+            {{ line }}
+          </a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Petite suggestion, car j'ai essayé de cliquer sur le numéro de la voie lyonnaise dans l'infobulle.